### PR TITLE
Fixing error(s) in display of GPS NO FIX and other error messages

### DIFF
--- a/inc/osdconfig.h
+++ b/inc/osdconfig.h
@@ -10,7 +10,7 @@
 #define PLAYUAV_VERSION_NUMBER          "1.1.1"
 // Change this to distinguish the release in some fashion that
 // version number doesn't cover
-#define PLAYUAV_VERSION_DESCRIPTION     "SLG BETA 1"
+#define PLAYUAV_VERSION_DESCRIPTION     "SLG BETA 2"
 
 void vTaskVCP(void *pvParameters);
 
@@ -360,11 +360,14 @@ typedef union {
     uint16_t Watts_fontsize;
     uint16_t Watts_align;
     
-    // From firmware_ver 11, PLAYUAV_VERSION 1.1.1
+    // From firmware_ver 11, PLAYUAV_VERSION 1.1.1, "SLG BETA 1"
     
     // Number of milliseconds to show the version splash panel
     uint16_t version_splash_milliseconds_to_show;
-
+    
+    // From firmware_ver 12, PLAYUAV_VERSION 1.1.1, "SLG BETA 2"    
+    uint16_t error_alert_milliseconds_to_show;
+    
 //		//below is unused. if add a param, reduce one item here
 //		uint16_t unused[EERROM_SIZE/2 - 104];
   }params;

--- a/inc/osdproc.h
+++ b/inc/osdproc.h
@@ -5,12 +5,14 @@
 
 /// GPS status codes
 enum GPS_Status {
-  NO_GPS = 0,                   ///< No GPS connected/detected
-  NO_FIX = 1,                   ///< Receiving valid GPS messages but no lock
-  GPS_OK_FIX_2D = 2,            ///< Receiving valid messages and 2D lock
-  GPS_OK_FIX_3D = 3,            ///< Receiving valid messages and 3D lock
-  GPS_OK_FIX_3D_DGPS = 4,       ///< Receiving valid messages and 3D lock with differential improvements
-  GPS_OK_FIX_3D_RTK = 5,        ///< Receiving valid messages and 3D lock, with relative-positioning improvements
+  NO_GPS = 0,                     ///< No GPS connected/detected
+  NO_FIX = 1,                     ///< Receiving valid GPS messages but no lock
+  GPS_OK_FIX_2D = 2,              ///< Receiving valid messages and 2D lock
+  GPS_OK_FIX_3D = 3,              ///< Receiving valid messages and 3D lock
+  GPS_OK_FIX_3D_DGPS = 4,         ///< Receiving valid messages and 3D lock with differential improvements
+  GPS_OK_FIX_3D_RTK_FLOAT = 5,    ///< Receiving valid messages and 3D lock, with relative-positioning improvements (RTK Float, 3D Position)
+  GPS_OK_FIX_TYPE_RTK_FIXED = 6,  ///< Receiving valid messages and 3D lock, with relative-positioning improvements (RTK Fixed, 3D Position)
+  GPS_OK_FIX_TYPE_STATIC = 7      ///< Static fixed, typically used for base stations  
 };
 
 void vTaskOSD(void *pvParameters);

--- a/src/board.c
+++ b/src/board.c
@@ -441,7 +441,13 @@ void checkDefaultParam() {
     eeprom_buffer.params.firmware_ver = 11;
     eeprom_buffer.params.version_splash_milliseconds_to_show = 5000;
     bNeedUpdateFlash = true;
-  } 
+  }
+  
+  if (eeprom_buffer.params.firmware_ver < 12) {
+    eeprom_buffer.params.firmware_ver = 12;
+    eeprom_buffer.params.error_alert_milliseconds_to_show = 1000;
+    bNeedUpdateFlash = true;
+  }
   
   bool ret = false;
   if (bNeedUpdateFlash)

--- a/src/osdproc.c
+++ b/src/osdproc.c
@@ -551,6 +551,9 @@ void draw_gps_status() {
 
   switch (osd_fix_type) {
   case NO_GPS:
+    // Only show this message when in fact there is no GPS attached
+    sprintf(tmp_str, "NOGPS");
+    break;
   case NO_FIX:
     sprintf(tmp_str, "NOFIX");
     break;
@@ -562,9 +565,22 @@ void draw_gps_status() {
     break;
   case GPS_OK_FIX_3D_DGPS:
     sprintf(tmp_str, "D3D-%d", (int) osd_satellites_visible);
+    break;    
+  // I don't expect users will ever see these in the real world, but let's
+  // handle them anyway
+  case GPS_OK_FIX_3D_RTK_FLOAT:
+    sprintf(tmp_str, "RTK-%d", (int) osd_satellites_visible);
+    break;    
+  case GPS_OK_FIX_TYPE_RTK_FIXED:
+    sprintf(tmp_str, "RTKF-%d", (int) osd_satellites_visible);
+    break;    
+  case GPS_OK_FIX_TYPE_STATIC:
+    sprintf(tmp_str, "STAT-%d", (int) osd_satellites_visible);
     break;
   default:
-    sprintf(tmp_str, "NOGPS");
+    // Some unknown GPS status, do our best to show we don't understand it in the 
+    // tiny space allowed, showing fix code and number of satellites locked
+    sprintf(tmp_str, "?FT:%d-%d", (int) osd_fix_type, (int) osd_satellites_visible);
     break;
   }
   write_string(tmp_str, eeprom_buffer.params.GpsStatus_posX,
@@ -801,7 +817,7 @@ void draw_distance_to_home() {
    
     // If home not set, give some indication that distance to home is currently meaningless
     if (osd_got_home == 0) {
-        sprintf(tmp_str, "H -%s", (int)tmp, dist_unit_short);
+        sprintf(tmp_str, "H -%s", dist_unit_short);
     // Display short units (meters/feet)
     } else if (tmp < convert_distance_divider) {
         sprintf(tmp_str, "H %d%s", (int)tmp, dist_unit_short);
@@ -1518,14 +1534,42 @@ void draw_wind(void) {
   write_string(tmp_str, posX + 15, posY, 0, 0, TEXT_VA_MIDDLE, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);
 }
 
+/*
+int debug_warnings_x = 30;
+int debug_warnings_y = 30;
+
+void debug_warnings_one() {    
+    sprintf(tmp_str, "GetSystimeMS(): %d", (int)GetSystimeMS());
+    write_string(tmp_str, debug_warnings_x, debug_warnings_y, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);
+    
+    sprintf(tmp_str, "last_warn_time: %d", (int)last_warn_time);
+    write_string(tmp_str, debug_warnings_x, debug_warnings_y + 15, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);
+}
+
+void debug_warnings_two() {    
+    sprintf(tmp_str, "osd_fix_type: %d", osd_fix_type);
+    write_string(tmp_str, debug_warnings_x, debug_warnings_y + 30, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);    
+}
+
+void debug_warnings_three(uint8_t warning[], const int warn_cnt) {    
+    sprintf(tmp_str, "last_warn_type: %d", last_warn_type);
+    write_string(tmp_str, debug_warnings_x, debug_warnings_y + 45, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);        
+    
+    for (int i = 0; i < warn_cnt; i++){
+        sprintf(tmp_str, "w[0]: %d", warning[i]);
+        write_string(tmp_str, debug_warnings_x, debug_warnings_y + 60 + (i * 15), 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);       
+    }
+}
+*/
+
 void draw_warning(void) {
   write_string(warn_str, eeprom_buffer.params.Alarm_posX, eeprom_buffer.params.Alarm_posY, 0, 0, TEXT_VA_TOP, eeprom_buffer.params.Alarm_align, 0, SIZE_TO_FONT[eeprom_buffer.params.Alarm_fontsize]);
 
-  if ((GetSystimeMS() - last_warn_time) < 1000)
-  {
+  // Show each warning a given number of milliseconds
+  if ((GetSystimeMS() - last_warn_time) < eeprom_buffer.params.error_alert_milliseconds_to_show) {
+    //debug_warnings_one();
     return;
   }
-
 
   bool haswarn = false;
   const static int warn_cnt = 6;
@@ -1533,6 +1577,7 @@ void draw_warning(void) {
 
   //no GPS fix!
   if (eeprom_buffer.params.Alarm_GPS_status_en == 1 && (osd_fix_type < GPS_OK_FIX_3D)) {
+    //debug_warnings_two();
     haswarn = true;
     warning[0] = 1;
   }
@@ -1556,7 +1601,6 @@ void draw_warning(void) {
 
   //over speed
   if (eeprom_buffer.params.Alarm_over_speed_en == 1 && (spd_comparison > eeprom_buffer.params.Alarm_over_speed)) {
-
     haswarn = true;
     warning[3] = 1;
   }
@@ -1585,50 +1629,77 @@ void draw_warning(void) {
 
   if (haswarn) {
     last_warn_time = GetSystimeMS();
-    if (last_warn_type > (warn_cnt - 1)) last_warn_type = 0;
+    // Wrap back to the start of the error type array
+    if (last_warn_type > warn_cnt) {
+        last_warn_type = 0;
+    }
+    
+    //debug_warnings_three(warning, warn_cnt);
 
-    if (last_warn_type == 0 && (warning[0] == 1)) {
-      warn_str = "NO GPS FIX";
+    if (last_warn_type == 0) {
       last_warn_type++;
-      return;
+      if (warning[0] == 1) {
+          warn_str = "NO GPS FIX";          
+          return;
+      }
     }
+    
+    if (last_warn_type == 1) {
+      last_warn_type++;
+      if (warning[1] == 1) {
+          warn_str = "LOW BATTERY";          
+          return;
+      }
+    }    
+    
+    if (last_warn_type == 2) {
+      last_warn_type++;
+      if (warning[2] == 1) {
+          warn_str = "SPEED LOW";          
+          return;
+      }
+    }    
+    
+    if (last_warn_type == 3) {
+      last_warn_type++;
+      if (warning[3] == 1) {
+          warn_str = "OVER SPEED";          
+          return;
+      }
+    }    
+    
+    if (last_warn_type == 4) {
+      last_warn_type++;
+      if (warning[4] == 1) {
+          warn_str = "LOW ALT";          
+          return;
+      }
+    }    
+    
+    if (last_warn_type == 5) {
+      last_warn_type++;
+      if (warning[5] == 1) {
+          warn_str = "HIGH ALT";          
+          return;
+      }
+    }    
+    
+    if (last_warn_type == 6) {
+      last_warn_type++;
+      if (warning[6] == 1) {
+          warn_str = "NO HOME POSITION SET";          
+          return;
+      }
+    }    
 
-    if (last_warn_type == 1 && (warning[1] == 1)) {
-      warn_str = "LOW BATTERY";
-      last_warn_type++;
-      return;
-    }
-
-    if (last_warn_type == 2 && (warning[2] == 1)) {
-      warn_str = "SPEED LOW";
-      last_warn_type++;
-      return;
-    }
-    if (last_warn_type == 3 && (warning[3] == 1)) {
-      warn_str = "OVER SPEED";
-      last_warn_type++;
-      return;
-    }
-    if (last_warn_type == 4 && (warning[4] == 1)) {
-      warn_str = "LOW ALT";
-      last_warn_type++;
-      return;
-    }
-    if (last_warn_type == 5 && (warning[5] == 1)) {
-      warn_str = "HIGH ALT";
-      last_warn_type++;
-      return;
-    }
-    if (last_warn_type == 6 && warning[6] == 1) {
-      warn_str = "NO HOME POSITION SET";
-      last_warn_type++;
-      return;
-    }
-    last_warn_type++;
+    // If we didn't match, there's a coding
+    // error of some kind. Warn the user/developer.
+    warn_str = "ERROR IN WARNING ROUTINE";
+    return;
   }
-  else{
-    warn_str = "";
-  }
+
+  // If you haven't found an error, this should ALWAYS get cleared
+  warn_str = "";
 }
 
 void debug_wps(void) {


### PR DESCRIPTION
The problem was originally pointed out by Paul Atherton here: http://fpvlab.com/forums/showthread.php?40658-A-Graphics-OSD-for-APM-Pixhawk&p=814872&viewfull=1#post814872

He observed that the "NO GPS FIX" error should clear once there is a 3D lock, and it does not. 

In the process of fixing this, I corrected a number of other related problems with the draw_warning() routine and associated code. Now it does what I believe it was originally supposed to do: Display each active error message in turn for a fixed number of (now configurable) milliseconds, as long as there are any errors. When there are no errors, it displays nothing.

I would like to take preflight error reporting a bit farther, but this is just a bug fix, attempting to get the code stable.
- I also found an error I'd already fixed creeping back in on the display of "H -M", showed "H null". This was from a bad cross-branch merge during pull request creation, my apologies.
- Bumping descriptive string for build.
