### PR TITLE
Concurrency Protection

### DIFF
--- a/inc/board.h
+++ b/inc/board.h
@@ -39,9 +39,9 @@ void Delay_us(u32 nus);
 #define OSD_LEVEL_SPI                           SPI2
 
 #define LINE_COUNTER_TIMER                      TIM4
-#define HSYNC_CAPTURE_TIMER             TIM2
-#define PIXEL_TIMER                                     TIM3
-#define SPI_CLOSE_DELAY_TIMER    TIM12
+#define HSYNC_CAPTURE_TIMER                     TIM2
+#define PIXEL_TIMER                             TIM3
+#define SPI_CLOSE_DELAY_TIMER                   TIM12
 
 #define USART1_RX_DMA                           DMA2_Stream2
 #define USART1_RX_DMA_IRQ                       DMA2_Stream2_IRQn
@@ -89,6 +89,7 @@ enum FC_Protocol
 
 void board_init(void);
 void module_init(void);
+void task_semaphores_init(void);
 
 uint32_t GetSystimeMS(void);    //return the current system time
 

--- a/inc/osdconfig.h
+++ b/inc/osdconfig.h
@@ -7,10 +7,10 @@
 #define EERROM_SIZE                             1024
 
 // Version number: major.minor.revision (1.2.6 for example)
-#define PLAYUAV_VERSION_NUMBER          "1.1.1"
+#define PLAYUAV_VERSION_NUMBER          "1.1.2"
 // Change this to distinguish the release in some fashion that
 // version number doesn't cover
-#define PLAYUAV_VERSION_DESCRIPTION     "SLG BETA 2"
+#define PLAYUAV_VERSION_DESCRIPTION     "CONCURRENCY FIXES - 11/01/2016"
 
 void vTaskVCP(void *pvParameters);
 

--- a/inc/osdproc.h
+++ b/inc/osdproc.h
@@ -31,6 +31,7 @@ void draw_uav2d(void);
 void draw_throttle(void);
 void draw_simple_attitude(void);
 void draw_home_direction(void);
+void draw_home_direction_debug_info(int x, int y, float absolute_home_bearing, float uav_compass_bearing, float relative_home_bearing);
 void draw_radar(void);
 void draw_flight_mode(void);
 void draw_arm_state(void);

--- a/inc/osdproc.h
+++ b/inc/osdproc.h
@@ -64,7 +64,6 @@ void draw_wind(void);
 void draw_map(void);
 void draw_panel_changed(void);
 void draw_warning(void);
-void draw_CWH(void);
 void draw_head_wp_home(void);
 void draw_watts(void);
 void draw_osd_linear_compass(void);

--- a/inc/osdvar.h
+++ b/inc/osdvar.h
@@ -3,122 +3,9 @@
 
 #include "board.h"
 
-/////////////////////////////////////////////////////////////////////////
-extern uint8_t mavbeat;
-extern uint32_t lastMAVBeat;
-extern uint32_t lastWritePanel;
-extern uint8_t waitingMAVBeats;
-extern uint8_t mav_type;
-extern uint8_t mav_system;
-extern uint8_t mav_component;
-extern uint8_t enable_mav_request;
-extern uint32_t sys_start_time;
-extern uint32_t heatbeat_start_time;
-extern uint32_t armed_start_time;
-extern uint32_t total_armed_time;
-
-/////////////////////////////////////////////////////////////////////////
-extern float osd_vbat_A;                 // Battery A voltage in milivolt
-extern int16_t osd_curr_A;                 // Battery A current
-extern int8_t osd_battery_remaining_A;    // 0 to 100 <=> 0 to 1000
-extern float osd_curr_consumed_mah; // total current drawn since startup in amp-hours
-
-extern float osd_pitch;                  // pitch from DCM
-extern float osd_roll;                   // roll from DCM
-extern float osd_yaw;                    // relative heading form DCM
-extern float osd_heading;                // ground course heading from GPS
-
-extern float osd_lat;                    // latidude
-extern float osd_lon;                    // longitude
-extern uint8_t osd_satellites_visible;     // number of satelites
-extern uint8_t osd_fix_type;               // GPS lock 0-1=no fix, 2=2D, 3=3D
-extern double osd_hdop;
-
-extern float osd_lat2;                    // latidude
-extern float osd_lon2;                    // longitude
-extern uint8_t osd_satellites_visible2;     // number of satelites
-extern uint8_t osd_fix_type2;               // GPS lock 0-1=no fix, 2=2D, 3=3D
-extern double osd_hdop2;
-
-extern float osd_airspeed;               // airspeed
-extern float osd_groundspeed;            // ground speed
-extern float osd_downVelocity;           // ground speed
-extern uint16_t osd_throttle;            // throtle
-extern float osd_alt;                    // altitude
-extern float osd_rel_alt;                // relative altitude	//  jmmods
-extern float osd_climb;
-extern float osd_climb_ma[10];
-extern int osd_climb_ma_index;
-extern float osd_total_trip_dist; //total trip distance since startup, calculated in meter
-
-extern float nav_roll; // Current desired roll in degrees
-extern float nav_pitch; // Current desired pitch in degrees
-extern int16_t nav_bearing; // Current desired heading in degrees
-extern int16_t wp_target_bearing; // Bearing to current MISSION/target in degrees
-extern int8_t wp_target_bearing_rotate_int;
-extern uint16_t wp_dist; // Distance to active MISSION in meters
-extern uint8_t wp_number; // Current waypoint number
-extern float alt_error; // Current altitude error in meters
-extern float aspd_error; // Current airspeed error in meters/second
-extern float xtrack_error; // Current crosstrack error on x-y plane in meters
-extern float eff; //Efficiency
-
-extern uint32_t custom_mode;
-extern bool motor_armed;
-extern bool last_motor_armed;
-extern uint8_t base_mode;
-extern uint8_t autopilot;
-
-extern bool osd_chan_cnt_above_eight;
-extern uint16_t osd_chan1_raw;
-extern uint16_t osd_chan2_raw;
-extern uint16_t osd_chan3_raw;
-extern uint16_t osd_chan4_raw;
-extern uint16_t osd_chan5_raw;
-extern uint16_t osd_chan6_raw;
-extern uint16_t osd_chan7_raw;
-extern uint16_t osd_chan8_raw;
-extern uint16_t osd_chan9_raw;
-extern uint16_t osd_chan10_raw;
-extern uint16_t osd_chan11_raw;
-extern uint16_t osd_chan12_raw;
-extern uint16_t osd_chan13_raw;
-extern uint16_t osd_chan14_raw;
-extern uint16_t osd_chan15_raw;
-extern uint16_t osd_chan16_raw;
-extern uint8_t osd_rssi; //raw value from mavlink
-
-extern uint8_t osd_got_home;               // tels if got home position or not
-extern float osd_home_lat;               // home latidude
-extern float osd_home_lon;               // home longitude
-extern float osd_home_alt;
-extern long osd_home_distance;          // distance from home
-extern uint32_t osd_home_bearing;
-extern uint8_t osd_alt_cnt;              // counter for stable osd_alt
-extern float osd_alt_prev;             // previous altitude
-
-extern float osd_windSpeed;
-extern float osd_windDir;
-
-extern volatile uint8_t current_panel;
-
-extern float atti_mp_scale;
-extern float atti_3d_scale;
-extern uint32_t atti_3d_min_clipX;
-extern uint32_t atti_3d_max_clipX;
-extern uint32_t atti_3d_min_clipY;
-extern uint32_t atti_3d_max_clipY;
-
 #define MAX_WAYPOINTS   20
 
-extern uint8_t got_mission_counts;
-extern uint8_t enable_mission_count_request;
-extern uint16_t mission_counts;
-extern uint8_t enable_mission_item_request;
-extern uint16_t current_mission_item_req_index;
 
-extern uint16_t wp_counts;
-extern uint8_t got_all_wps;
 // a self contained waypoint list
 typedef struct WAYPOINT_TYP {
 //	float para1;
@@ -138,8 +25,288 @@ typedef struct WAYPOINT_TYP {
 //    uint8_t autocontinue;
 } WAYPOINT, *WAYPOINT_PTR;
 
-extern WAYPOINT wp_list[MAX_WAYPOINTS];
+/* 
 
-extern int8_t osd_offset_Y;
-extern int8_t osd_offset_X;
+osd_state_struct variables should have a lifetime that flows left to right
+like this:
+
+Serial reader (Mavlink/UAVTalk/Etc) => Airlock => OSDProc
+
+The Mavlink (mavlink_osd_state) and OSDProc (osdproc_osd_state) 
+instances of this struct are owned completely by Mavlink and
+OSDProc; no other threads should access them. The Airlock is
+where exchange between them happens, and access to the Airlock
+is controlled via a mutex. 
+
+There are two copy operations that use
+copy_osd_state_thread_safe to copy from Mavlink => Airlock, and
+Airlock => OSDProc.  The idea is to have simple, ready access to
+the osd_state_struct variable's contents during Mavlink reading 
+and OSD writing, and to avoid ever pending on a slow serial read
+operation during a fast screen drawing operation.
+
+If that were all there were to it, it would be very clean. But some
+code elsewhere (like Board.c) also updates values directly in the airlock,
+and the mutex is used to control access to these as well. 
+
+See also the other_osd_state_struct, which have a less predictable
+lifetime than osd_state_struct, and have a variety of convenience 
+accessors to make using them less aggravating and tedious.
+
+-- SLG
+*/
+typedef struct osd_state_struct osd_state;
+struct osd_state_struct {
+    float osd_alt;                               // Current altitude
+    
+    float osd_lat;                               // GPS Latitude
+    float osd_lon;                               // GPS Longitude
+        
+    float osd_vbat_A;                            // Battery A voltage in milivolt
+    int16_t osd_curr_A;                          // Battery A current
+    int8_t osd_battery_remaining_A;              // 0 to 100 <=> 0 to 1000
+
+    float osd_pitch;                             // pitch from DCM
+    float osd_roll;                              // roll from DCM
+    // No usage in OSDProc yet, but it starts in Mavlink so is safe to put here.
+    float osd_yaw;                               // relative heading form DCM
+    float osd_heading;                           // ground course heading from GPS
+
+    uint8_t osd_satellites_visible;              // number of satelites
+    uint8_t osd_fix_type;                        // GPS lock 0-1=no fix, 2=2D, 3=3D
+    double osd_hdop;                             // GPS HDOP
+    
+    float osd_lat2;                              // latitude GPS #2
+    float osd_lon2;                              // longitude GPS #2
+    uint8_t osd_satellites_visible2;             // number of satelites GPS #2
+    uint8_t osd_fix_type2;                       // GPS lock 0-1=no fix, 2=2D, 3=3D GPS #2
+    double osd_hdop2;
+
+    float osd_airspeed;                          // airspeed -- NOTE, set to -1.0f by default. Was this important?
+    float osd_groundspeed;                       // ground speed
+
+    uint16_t osd_throttle;                       // throttle
+
+    float osd_rel_alt;                           // relative altitude -- jmmods
+    float osd_climb;
+
+    float nav_roll;                              // Current desired roll in degrees
+    float nav_pitch;                             // Current desired pitch in degrees
+    int16_t nav_bearing;                         // Current desired heading in degrees
+    
+    uint16_t wp_dist;                            // Distance to active MISSION in meters
+    uint8_t wp_number;                           // Current waypoint number
+    float alt_error;                             // Current altitude error in meters
+    float aspd_error;                            // Current airspeed error in meters/second
+    float xtrack_error;                          // Current crosstrack error on x-y plane in meters
+
+    bool motor_armed;
+    bool last_motor_armed;
+    uint8_t autopilot;
+    uint8_t base_mode;
+    uint32_t custom_mode;
+    
+    int16_t wp_target_bearing;                  // Bearing to current MISSION/target in degrees
+
+    bool osd_chan_cnt_above_eight;
+    uint16_t osd_chan1_raw;
+    uint16_t osd_chan2_raw;
+    uint16_t osd_chan3_raw;
+    uint16_t osd_chan4_raw;
+    uint16_t osd_chan5_raw;
+    uint16_t osd_chan6_raw;
+    uint16_t osd_chan7_raw;
+    uint16_t osd_chan8_raw;
+    uint16_t osd_chan9_raw;
+    uint16_t osd_chan10_raw;
+    uint16_t osd_chan11_raw;
+    uint16_t osd_chan12_raw;
+    uint16_t osd_chan13_raw;
+    uint16_t osd_chan14_raw;
+    uint16_t osd_chan15_raw;
+    uint16_t osd_chan16_raw;
+    uint8_t osd_rssi;                           //raw value from mavlink    
+    
+    float osd_windSpeed;
+    float osd_windDir;
+
+    uint8_t got_mission_counts;
+    uint8_t enable_mission_count_request;
+    uint16_t mission_counts;
+    uint8_t enable_mission_item_request;
+    uint16_t current_mission_item_req_index;
+       
+    uint16_t wp_counts;
+    uint8_t got_all_wps;     
+    WAYPOINT wp_list[MAX_WAYPOINTS];  
+};
+
+// TODO-- A Clear function to get 0's initialized as per the global initialziers
+// accomplished. 
+
+
+/* 
+These are global variables that do NOT flow strictly from 
+the serial protocols (Mavlink/Uavtalk/etc) to the OSD, but 
+have other global-type lifetimes.
+
+Not every one of these globals needs mutex protection, but
+given the errors of the past it seems wise to err on the
+conservative side, assuming performance problems can
+be avoided. 
+
+Please use the appropriate mutex when accessing these variables.
+
+-- SLG
+*/
+typedef struct other_osd_state_struct other_osd_state;
+struct other_osd_state_struct {  
+
+    uint8_t mavbeat;
+    uint32_t lastMAVBeat;
+    uint32_t lastWritePanel;
+    uint8_t waitingMAVBeats;
+    uint8_t mav_type;
+    uint8_t mav_system;
+    uint8_t mav_component;
+    uint8_t enable_mav_request;
+    uint32_t sys_start_time;
+    uint32_t heartbeat_start_time;
+    uint32_t armed_start_time;
+    uint32_t total_armed_time;
+
+    float osd_total_trip_dist; 
+    float osd_climb_ma[10];
+    int osd_climb_ma_index; 
+
+    float osd_curr_consumed_mah;                 // total current drawn since startup in amp-hours
+    
+    uint8_t osd_got_home;                        // tells if got home position or not
+    float osd_home_lat;                          // home latitude
+    float osd_home_lon;                          // home longitude
+    float osd_home_alt;
+    long osd_home_distance;                      // distance from home
+    uint32_t osd_home_bearing;
+    uint8_t osd_alt_cnt;                         // counter for stable osd_alt
+    float osd_alt_prev;                          // previous altitude      
+    
+    // volatile probably isn't doing what the original author thought here.. remove now that it's mutex'd?
+    volatile uint8_t current_panel;   
+
+    float atti_mp_scale;
+    float atti_3d_scale;
+    uint32_t atti_3d_min_clipX;
+    uint32_t atti_3d_max_clipX;
+    uint32_t atti_3d_min_clipY;
+    uint32_t atti_3d_max_clipY;
+     
+    int8_t osd_offset_X;        
+    int8_t osd_offset_Y;            
+};
+    
+/////////////////////////////////////////////////////////////////////////
+
+// Utility functions to clear structs to zero. These require careful
+// thought when used, since the various structs have very different 
+// lifetimes.
+
+void clear_osd_state_struct(osd_state * pOsd_state);
+void clear_other_ost_state_struct(other_osd_state * pOther_osd_state);
+
+void clear_certain_global_mutexed_structs();
+              
+/////////////////////////////////////////////////////////////////////////
+
+void variable_mutexes_init(void);
+
+// Airlock OSD state. Access controlled with mutex, take care!
+// Values in the airlock start in Mavlink/Uavtalk/other serial protocol,
+// then move to the OSD thread.
+extern osd_state airlock_osd_state;
+
+// Other OSD state. This is other globals that need mutex control,
+// but may not be flowing directly out of mavlink, but rather are
+// manipulated elswhere. This is more ad-hoc stuff, with less of 
+// a pattern to the flow.
+extern other_osd_state adhoc_osd_state;
+
+// Copy an osd_state object in a thread-safe manner
+void copy_osd_state_thread_safe(osd_state * p_osd_state_source, 
+                                osd_state * p_osd_state_target,
+                                TickType_t tick_delay);
+                                
+/////////////////////////////////////////////////////////////////////////
+// Accessor convenience functions for accessing protected variables 
+// between tasks. Hides details of mutexes and helps prevent accidental 
+// misuse.
+/////////////////////////////////////////////////////////////////////////
+
+float get_atti_3d_scale();
+float get_atti_mp_scale();
+float get_current_consumed_mah();
+
+uint32_t get_osd_home_bearing();
+void set_osd_home_bearing(uint32_t new_osd_home_bearing);
+
+float get_osd_home_lat();
+void set_osd_home_lat(long new_osd_home_lat);
+
+float get_osd_home_lon();
+void set_osd_home_lon(long new_osd_home_lon);
+
+long get_osd_home_distance();
+void set_osd_home_distance(long new_osd_home_distance);
+
+uint8_t get_osd_got_home();
+void set_osd_got_home(uint8_t new_osd_got_home);
+
+uint8_t get_osd_alt_cnt();
+void set_osd_alt_cnt(uint8_t new_osd_alt_cnt);
+
+uint8_t get_osd_alt_prev();
+void set_osd_alt_prev(uint8_t new_osd_alt_prev);
+
+uint8_t get_osd_home_alt();
+void set_osd_home_alt(uint8_t new_osd_home_alt);
+
+uint8_t get_current_panel();
+void set_current_panel(uint8_t new_current_panel);  
+
+uint8_t get_mavbeat();
+void set_mavbeat(uint8_t new_mavbeat);
+
+uint32_t get_lastMAVBeat();
+void set_lastMAVBeat(uint32_t new_lastMAVBeat);
+
+uint32_t get_lastWritePanel();
+void set_lastWritePanel(uint32_t new_lastWritePanel);
+
+uint8_t get_waitingMAVBeats();
+void set_waitingMAVBeats(uint8_t new_waitingMAVBeats);
+
+uint8_t get_mav_type();
+void set_mav_type(uint8_t new_mav_type);
+
+uint8_t get_mav_system();
+void set_mav_system(uint8_t new_mav_system);
+
+uint8_t get_mav_component();
+void set_mav_component(uint8_t new_mav_component);
+
+uint8_t get_enable_mav_request();
+void set_enable_mav_request(uint8_t new_enable_mav_request);
+
+uint32_t get_sys_start_time();
+void set_sys_start_time(uint32_t new_sys_start_time);
+
+uint32_t get_heartbeat_start_time();
+void set_heartbeat_start_time(uint32_t new_heartbeat_start_time);
+
+uint32_t get_armed_start_time();
+void set_armed_start_time(uint32_t new_armed_start_time);
+
+uint32_t get_total_armed_time();
+void set_total_armed_time(uint32_t new_total_armed_time);
+
+
 #endif

--- a/inc/osdvar.h
+++ b/inc/osdvar.h
@@ -231,9 +231,9 @@ extern osd_state airlock_osd_state;
 extern other_osd_state adhoc_osd_state;
 
 // Copy an osd_state object in a thread-safe manner
-void copy_osd_state_thread_safe(osd_state * p_osd_state_source, 
-                                osd_state * p_osd_state_target,
-                                TickType_t tick_delay);
+void copy_osd_state(osd_state * p_osd_state_source, 
+                    osd_state * p_osd_state_target,
+                    TickType_t tick_delay);
                                 
 /////////////////////////////////////////////////////////////////////////
 // Accessor convenience functions for accessing protected variables 

--- a/src/UAVObj.c
+++ b/src/UAVObj.c
@@ -117,6 +117,7 @@ void uav3D_init(void) {
                    -eeprom_buffer.params.Atti_3D_posY + GRAPHICS_Y_MIDDLE, 0);
   Translate_OBJECT4DV1(&uav3D, &v);
   //scale the mode
+  float atti_3d_scale = get_atti_3d_scale();
   VECTOR4D_INITXYZ(&v, atti_3d_scale, atti_3d_scale, 0);
   Scale_OBJECT4DV1(&uav3D, &v);
 
@@ -139,6 +140,7 @@ void simple_attitude_init(void) {
     VECTOR2D_INITXYZ(&(simple_attitude.vlist_local[index + 3]), x + line_length, 0);
     i++;
   }
+  float atti_mp_scale = get_atti_mp_scale();
   Scale_Polygon2D(&simple_attitude, atti_mp_scale, atti_mp_scale);
 }
 
@@ -224,6 +226,7 @@ void uav2D_init(void) {
 
 
   // do a quick scale on the vertices
+  float atti_mp_scale = get_atti_mp_scale();  
   Scale_Polygon2D(&uav2D, atti_mp_scale, atti_mp_scale);
 
   // initialize roll scale

--- a/src/board.c
+++ b/src/board.c
@@ -28,17 +28,57 @@
 #include "osdvar.h"
 #include <math.h>
 
+
 void vTaskHeartBeat(void *pvParameters);
 void vTask10HZ(void *pvParameters);
 void triggerVideo(void);
 void triggerPanel(void);
 void checkDefaultParam(void);
 
+// Intra-task communication semaphores
+extern xSemaphoreHandle onScreenDisplaySemaphore;
+extern xSemaphoreHandle onMavlinkSemaphore;
+extern xSemaphoreHandle onUAVTalkSemaphore;
+
+// This mutex controls access to the Mavlink OSD State
+extern xSemaphoreHandle osd_state_mavlink_mutex;
+// This mutex controls access to the airlock OSD State
+extern xSemaphoreHandle osd_state_airlock_mutex;
+// this mutex controls access to other OSD state
+extern xSemaphoreHandle osd_state_adhoc_mutex;
+
+// This is the actual Mavlink OSDState. 
+// Only access via osd_state_mavlink_mutex!
+extern osd_state mavlink_osd_state;
+
 uint8_t video_switch = 0;
 
 xTaskHandle xTaskVCPHandle;
 
 int32_t pwmPanelNormal = 0;
+
+void set_up_offsets_and_scale() {
+  // Take the ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+    //fabs, make sure not broken the VBI
+    adhoc_osd_state.osd_offset_Y = fabs(eeprom_buffer.params.osd_offsetY);
+
+    adhoc_osd_state.osd_offset_X = eeprom_buffer.params.osd_offsetX;
+    if (eeprom_buffer.params.osd_offsetX_sign == 0) {
+        adhoc_osd_state.osd_offset_X = adhoc_osd_state.osd_offset_X * -1;
+    }
+
+    adhoc_osd_state.atti_mp_scale = (float)eeprom_buffer.params.Atti_mp_scale_real + (float)eeprom_buffer.params.Atti_mp_scale_frac * 0.01;
+    adhoc_osd_state.atti_3d_scale = (float)eeprom_buffer.params.Atti_3D_scale_real + (float)eeprom_buffer.params.Atti_3D_scale_frac * 0.01;
+    adhoc_osd_state.atti_3d_min_clipX = eeprom_buffer.params.Atti_mp_posX - (uint32_t)(22 * adhoc_osd_state.atti_mp_scale);
+    adhoc_osd_state.atti_3d_max_clipX = eeprom_buffer.params.Atti_mp_posX + (uint32_t)(22 * adhoc_osd_state.atti_mp_scale);
+    adhoc_osd_state.atti_3d_min_clipY = eeprom_buffer.params.Atti_mp_posY - (uint32_t)(30 * adhoc_osd_state.atti_mp_scale);
+    adhoc_osd_state.atti_3d_max_clipY = eeprom_buffer.params.Atti_mp_posY + (uint32_t)(34 * adhoc_osd_state.atti_mp_scale);      
+           
+    // Release the ad-hoc mutex
+    xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
 
 void board_init(void) {
   GPIO_InitTypeDef gpio;
@@ -106,7 +146,6 @@ void board_init(void) {
 
   Build_Sin_Cos_Tables();
 
-
   bool force_clear_params = false;
   force_clear_params = test_force_clear_all_params();
   if (force_clear_params)
@@ -117,21 +156,8 @@ void board_init(void) {
   LoadParams();
   checkDefaultParam();
   SPI_MAX7456_init();
-
-  //fabs, make sure not broken the VBI
-  osd_offset_Y = fabs(eeprom_buffer.params.osd_offsetY);
-
-  osd_offset_X = eeprom_buffer.params.osd_offsetX;
-  if (eeprom_buffer.params.osd_offsetX_sign == 0) {
-    osd_offset_X = osd_offset_X * -1;
-  }
-
-  atti_mp_scale = (float)eeprom_buffer.params.Atti_mp_scale_real + (float)eeprom_buffer.params.Atti_mp_scale_frac * 0.01;
-  atti_3d_scale = (float)eeprom_buffer.params.Atti_3D_scale_real + (float)eeprom_buffer.params.Atti_3D_scale_frac * 0.01;
-  atti_3d_min_clipX = eeprom_buffer.params.Atti_mp_posX - (uint32_t)(22 * atti_mp_scale);
-  atti_3d_max_clipX = eeprom_buffer.params.Atti_mp_posX + (uint32_t)(22 * atti_mp_scale);
-  atti_3d_min_clipY = eeprom_buffer.params.Atti_mp_posY - (uint32_t)(30 * atti_mp_scale);
-  atti_3d_max_clipY = eeprom_buffer.params.Atti_mp_posY + (uint32_t)(34 * atti_mp_scale);
+  
+  set_up_offsets_and_scale();
 }
 
 void module_init(void) {
@@ -160,17 +186,124 @@ void module_init(void) {
     break;
   }
 
-
 //	xTaskCreate( DJICanTask, (const char*)"DJI CAN",
 //	STACK_SIZE_MIN, NULL, THREAD_PRIO_HIGH, NULL );
 }
 
+// Initialize the semaphores used for intra-task communication
+void task_semaphores_init() {
+  vSemaphoreCreateBinary(onScreenDisplaySemaphore);
+  vSemaphoreCreateBinary(onMavlinkSemaphore);
+  vSemaphoreCreateBinary(onUAVTalkSemaphore);
+}
+
+/*
+void watchdog_init() {
+  // Two seconds is a generous interval to monitor for deadlock/crash,
+  // but hopefully not so long that a pilot can't live without the OSD.
+  // We can shorten this interval if need be.  
+  if (TM_WATCHDOG_Init(TM_WATCHDOG_Timeout_2s)) {
+    //System was reset by watchdog
+    // TODO: We could put up a message informing the user the OSD crashed and rebooted
+    LEDToggle(LED_GREEN);
+  } else {
+    //System was not reset by watchdog
+    LEDToggle(LED_BLUE);
+  }    
+}
+
+void check_for_watchdog_problems() {
+    //lkjsdflk;asdfjas;dfja    
+}
+*/
+
 void vTaskHeartBeat(void *pvParameters) {
+    
+  //watchdog_init();    
+
   for (;; )
   {
     LEDToggle(LED_GREEN);
+    //check_for_watchdog_problems();
     vTaskDelay(500 / portTICK_RATE_MS);
   }
+}
+
+void update_current_consumed_estimate() {    
+    // Update the values directly (in/from) the airlock, which is presumed to be
+    // reasonably current
+    if (xSemaphoreTake(osd_state_airlock_mutex, portMAX_DELAY) == pdTRUE ) {
+         float current_increment = (airlock_osd_state.osd_curr_A * 0.00027777778f);
+        // Release the airlock mutex
+        xSemaphoreGive(osd_state_airlock_mutex);
+                
+        // calculate osd_curr_consumed_mah(simulation) 
+        if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+            adhoc_osd_state.osd_curr_consumed_mah += current_increment; 
+            // Release the ad-hoc mutex
+            xSemaphoreGive(osd_state_adhoc_mutex);
+        }        
+    }    
+}     
+
+void update_total_trip_distance() {
+    // Update the values directly (in/from) the airlock, which is presumed to be
+    // reasonably current
+    if (xSemaphoreTake(osd_state_airlock_mutex, portMAX_DELAY) == pdTRUE ) {
+        float additional_trip_distance = 0.0f;
+        
+        // calculate osd_total_trip_dist(simulation)
+        if (airlock_osd_state.osd_groundspeed > 1.0f) {
+            // jmmods > for calculation of trip , Groundspeed is better than airspeed        
+            additional_trip_distance = (airlock_osd_state.osd_groundspeed * 0.1f); 
+        }    
+        // Release the airlock mutex
+        xSemaphoreGive(osd_state_airlock_mutex);     
+
+        // Update total trip distance using the ad-hoc mutex & global structure
+        if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+            adhoc_osd_state.osd_total_trip_dist += additional_trip_distance; 
+            // Release the ad-hoc mutex
+            xSemaphoreGive(osd_state_adhoc_mutex);                          
+        }
+    }
+}  
+
+void update_mission_counts() {
+    bool should_request_mission_count = false;
+    bool should_request_mission_item = false;
+    uint16_t TEMP_current_mission_item_request_index = -1;
+        
+    // These updates happen as early as Mavlink since the Mavlink task
+    // looks at these values to determine when to query / re-query for Mission waypoints.
+
+    // Lock access to Mavlink OSDState via mutex
+    if (xSemaphoreTake(osd_state_mavlink_mutex, portMAX_DELAY) == pdTRUE ) {
+        if (mavlink_osd_state.enable_mission_count_request == 1)
+        {
+          should_request_mission_count = true;
+          mavlink_osd_state.enable_mission_count_request = 0;
+        }
+
+        if (mavlink_osd_state.enable_mission_item_request == 1)
+        {
+          should_request_mission_item = true;
+          TEMP_current_mission_item_request_index = mavlink_osd_state.current_mission_item_req_index;
+        }
+        // Release the Mavlink mutex ASAP
+        xSemaphoreGive(osd_state_mavlink_mutex);
+
+        // These are Mavlink calls, and might be slow, so we take pains to do them
+        // outside the possession of the mutex to prevent any potential pend.
+
+        if (should_request_mission_count == true) {
+          request_mission_count();
+        }
+        
+        if (should_request_mission_item == true){
+            request_mission_item(TEMP_current_mission_item_request_index);
+        }
+    }
 }
 
 void vTask10HZ(void *pvParameters) {
@@ -178,11 +311,8 @@ void vTask10HZ(void *pvParameters) {
   {
     vTaskDelay(100 / portTICK_RATE_MS);
 
-    // calculate osd_curr_consumed_mah(simulation)
-    osd_curr_consumed_mah += (osd_curr_A * 0.00027777778f);
-
-    // calculate osd_total_trip_dist(simulation)
-    if (osd_groundspeed > 1.0f) osd_total_trip_dist += (osd_groundspeed * 0.1f);           // jmmods > for calculation of trip , Groundspeed is better than airspeed
+    update_current_consumed_estimate();
+    update_total_trip_distance();
 
     //trigger video switch
     if (eeprom_buffer.params.PWM_Video_en)
@@ -196,56 +326,52 @@ void vTask10HZ(void *pvParameters) {
       triggerPanel();
     }
 
-    //if no mavlink update for 2 secs, show waring and request mavlink rate again
-    if (GetSystimeMS() > (lastMAVBeat + 2200))
+    //if no mavlink update for 2 secs, show warning and request mavlink rate again
+    if (GetSystimeMS() > (get_lastMAVBeat() + 2200))
     {
-      heatbeat_start_time = 0;
-      waitingMAVBeats = 1;
+      set_heartbeat_start_time(0);
+      set_waitingMAVBeats(1);
     }
 
-    if (enable_mav_request == 1)
+    if (get_enable_mav_request() == 1)
     {
       for (int n = 0; n < 3; n++) {
         request_mavlink_rates();            //Three times to certify it will be readed
         vTaskDelay(50 / portTICK_RATE_MS);
       }
-      enable_mav_request = 0;
-      waitingMAVBeats = 0;
-      lastMAVBeat = GetSystimeMS();
+      set_enable_mav_request(0);
+      set_waitingMAVBeats(0);
+      set_lastMAVBeat(GetSystimeMS());
     }
 
-    if (enable_mission_count_request == 1)
-    {
-      request_mission_count();
-      enable_mission_count_request = 0;
-    }
-
-    if (enable_mission_item_request == 1)
-    {
-      request_mission_item(current_mission_item_req_index);
-    }
-
+    update_mission_counts();
   }
 }
 
 void triggerVideo(void) {
   static uint16_t video_ch_raw;
   static bool video_trigger = false;
-
+  
   video_ch_raw = 0;
-  if (eeprom_buffer.params.PWM_Video_ch == 5) video_ch_raw = osd_chan5_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 6) video_ch_raw = osd_chan6_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 7) video_ch_raw = osd_chan7_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 8) video_ch_raw = osd_chan8_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 9) video_ch_raw = osd_chan9_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 10) video_ch_raw = osd_chan10_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 11) video_ch_raw = osd_chan11_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 12) video_ch_raw = osd_chan12_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 13) video_ch_raw = osd_chan13_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 14) video_ch_raw = osd_chan14_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 15) video_ch_raw = osd_chan15_raw;
-  else if (eeprom_buffer.params.PWM_Video_ch == 16) video_ch_raw = osd_chan16_raw;
 
+  // Take airlock mutex
+  if (xSemaphoreTake(osd_state_airlock_mutex, portMAX_DELAY) == pdTRUE ) {
+      if (eeprom_buffer.params.PWM_Video_ch == 5) video_ch_raw = airlock_osd_state.osd_chan5_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 6) video_ch_raw = airlock_osd_state.osd_chan6_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 7) video_ch_raw = airlock_osd_state.osd_chan7_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 8) video_ch_raw = airlock_osd_state.osd_chan8_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 9) video_ch_raw = airlock_osd_state.osd_chan9_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 10) video_ch_raw = airlock_osd_state.osd_chan10_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 11) video_ch_raw = airlock_osd_state.osd_chan11_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 12) video_ch_raw = airlock_osd_state.osd_chan12_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 13) video_ch_raw = airlock_osd_state.osd_chan13_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 14) video_ch_raw = airlock_osd_state.osd_chan14_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 15) video_ch_raw = airlock_osd_state.osd_chan15_raw;
+      else if (eeprom_buffer.params.PWM_Video_ch == 16) video_ch_raw = airlock_osd_state.osd_chan16_raw;
+      // Release the airlock mutex
+      xSemaphoreGive(osd_state_airlock_mutex);
+  }      
+      
   if (eeprom_buffer.params.PWM_Video_mode == 0) {
     if (video_ch_raw > eeprom_buffer.params.PWM_Video_value) {
       if (!video_trigger) {
@@ -276,40 +402,76 @@ void triggerVideo(void) {
   }
 }
 
+// Request a reload of the Waypoints from outside the Mavlink thread.
+// (Requests outside the Mavlink thread require mutex locking)
+void request_reload_of_waypoints_outside_mavlink_thread() {
+    // Lock access to Mavlink OSDState via mutex
+    if (xSemaphoreTake(osd_state_mavlink_mutex, portMAX_DELAY) == pdTRUE ) {
+        // Request a reload of waypoints
+        mavlink_osd_state.enable_mission_count_request = 1;
+        // Release the Mavlink OSDState mutex
+        xSemaphoreGive(osd_state_mavlink_mutex);
+    }
+}
+
 void triggerPanel(void) {
   static uint16_t panel_ch_raw;
   static bool panel_trigger = false;
 
   panel_ch_raw = 0;
-  if (eeprom_buffer.params.PWM_Panel_ch == 5) panel_ch_raw = osd_chan5_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 6) panel_ch_raw = osd_chan6_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 7) panel_ch_raw = osd_chan7_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 8) panel_ch_raw = osd_chan8_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 9) panel_ch_raw = osd_chan9_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 10) panel_ch_raw = osd_chan10_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 11) panel_ch_raw = osd_chan11_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 12) panel_ch_raw = osd_chan12_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 13) panel_ch_raw = osd_chan13_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 14) panel_ch_raw = osd_chan14_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 15) panel_ch_raw = osd_chan15_raw;
-  else if (eeprom_buffer.params.PWM_Panel_ch == 16) panel_ch_raw = osd_chan16_raw;
+  
+  // Take airlock mutex
+  if (xSemaphoreTake(osd_state_airlock_mutex, portMAX_DELAY) == pdTRUE ) {
+      if (eeprom_buffer.params.PWM_Panel_ch == 5) panel_ch_raw = airlock_osd_state.osd_chan5_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 6) panel_ch_raw = airlock_osd_state.osd_chan6_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 7) panel_ch_raw = airlock_osd_state.osd_chan7_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 8) panel_ch_raw = airlock_osd_state.osd_chan8_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 9) panel_ch_raw = airlock_osd_state.osd_chan9_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 10) panel_ch_raw = airlock_osd_state.osd_chan10_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 11) panel_ch_raw = airlock_osd_state.osd_chan11_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 12) panel_ch_raw = airlock_osd_state.osd_chan12_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 13) panel_ch_raw = airlock_osd_state.osd_chan13_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 14) panel_ch_raw = airlock_osd_state.osd_chan14_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 15) panel_ch_raw = airlock_osd_state.osd_chan15_raw;
+      else if (eeprom_buffer.params.PWM_Panel_ch == 16) panel_ch_raw = airlock_osd_state.osd_chan16_raw;
+      // Release the airlock mutex
+      xSemaphoreGive(osd_state_airlock_mutex);
+  }    
+  
+    // Did the panel value get changed by this routine?
+    bool panel_value_changed = false;
 
-  if (eeprom_buffer.params.PWM_Panel_mode == 0) {
-    if ((panel_ch_raw > eeprom_buffer.params.PWM_Panel_value)) {
-      if (!panel_trigger) {
-        panel_trigger = true;
-        current_panel++;
+    // Panel info access is controlled by ad-hoc mutex
+    if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      int original_panel_value = adhoc_osd_state.current_panel;
+      if (eeprom_buffer.params.PWM_Panel_mode == 0) {
+        if ((panel_ch_raw > eeprom_buffer.params.PWM_Panel_value)) {
+          if (!panel_trigger) {
+            panel_trigger = true;
+            adhoc_osd_state.current_panel++;
+          }
+        } else {
+          panel_trigger = false;
+        }
+      } else {
+        if (panel_ch_raw > 950 && panel_ch_raw < 2050) {
+          adhoc_osd_state.current_panel = ceil((panel_ch_raw - 950) / (1100 / (float) eeprom_buffer.params.Max_panels));
+        } else {
+          adhoc_osd_state.current_panel = 1;
+        }
       }
-    } else {
-      panel_trigger = false;
+      
+      panel_value_changed = adhoc_osd_state.current_panel != original_panel_value;
+      
+      // Release the ad-hoc mutex
+      xSemaphoreGive(osd_state_adhoc_mutex);
     }
-  } else {
-    if (panel_ch_raw > 950 && panel_ch_raw < 2050) {
-      current_panel = ceil((panel_ch_raw - 950) / (1100 / (float) eeprom_buffer.params.Max_panels));
-    } else {
-      current_panel = 1;
+    
+    // If we changed panels, reload the waypoints 
+    // TODO: Make conditional on EEPROM value to allow configuration
+    if (panel_value_changed) {
+        request_reload_of_waypoints_outside_mavlink_thread();
     }
-  }
 }
 
 uint32_t GetSystimeMS(void) {

--- a/src/board.c
+++ b/src/board.c
@@ -197,34 +197,11 @@ void task_semaphores_init() {
   vSemaphoreCreateBinary(onUAVTalkSemaphore);
 }
 
-/*
-void watchdog_init() {
-  // Two seconds is a generous interval to monitor for deadlock/crash,
-  // but hopefully not so long that a pilot can't live without the OSD.
-  // We can shorten this interval if need be.  
-  if (TM_WATCHDOG_Init(TM_WATCHDOG_Timeout_2s)) {
-    //System was reset by watchdog
-    // TODO: We could put up a message informing the user the OSD crashed and rebooted
-    LEDToggle(LED_GREEN);
-  } else {
-    //System was not reset by watchdog
-    LEDToggle(LED_BLUE);
-  }    
-}
-
-void check_for_watchdog_problems() {
-    //lkjsdflk;asdfjas;dfja    
-}
-*/
-
 void vTaskHeartBeat(void *pvParameters) {
     
-  //watchdog_init();    
-
   for (;; )
   {
     LEDToggle(LED_GREEN);
-    //check_for_watchdog_problems();
     vTaskDelay(500 / portTICK_RATE_MS);
   }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,6 @@
 
 #include "board.h"
 #include "osdvar.h"
-#include "tm_stm32f4_watchdog.h"
 
 uint64_t u64Ticks = 0;        // Counts OS ticks (default = 1000Hz).
 uint64_t u64IdleTicks = 0;    // Value of u64IdleTicksCnt is copied once per sec.

--- a/src/main.c
+++ b/src/main.c
@@ -15,12 +15,15 @@
  */
 
 #include "board.h"
+#include "osdvar.h"
+#include "tm_stm32f4_watchdog.h"
 
 uint64_t u64Ticks = 0;        // Counts OS ticks (default = 1000Hz).
 uint64_t u64IdleTicks = 0;    // Value of u64IdleTicksCnt is copied once per sec.
 uint64_t u64IdleTicksCnt = 0; // Counts when the OS has no task to execute.
 bool stackOverflow = false;
 
+// Intra-task communication semaphores
 xSemaphoreHandle onScreenDisplaySemaphore;
 xSemaphoreHandle onMavlinkSemaphore;
 xSemaphoreHandle onUAVTalkSemaphore;
@@ -33,12 +36,11 @@ xSemaphoreHandle onUAVTalkSemaphore;
 int main(void) {
   /* enable FPU on Cortex-M4F core */
   SCB_CPACR |= ((3UL << 10 * 2) | (3UL << 11 * 2));   /* set CP10 Full Access and set CP11 Full Access */
-
-
-  vSemaphoreCreateBinary(onScreenDisplaySemaphore);
-  vSemaphoreCreateBinary(onMavlinkSemaphore);
-  vSemaphoreCreateBinary(onUAVTalkSemaphore);
-
+    
+  task_semaphores_init();
+  variable_mutexes_init();
+  clear_certain_global_mutexed_structs();
+  
   board_init();
   module_init();
 
@@ -73,4 +75,3 @@ void vApplicationStackOverflowHook(uintptr_t pxTask, signed char * pcTaskName) {
   wait_here = true;
 #endif
 }
-

--- a/src/osdmavlink.c
+++ b/src/osdmavlink.c
@@ -320,7 +320,7 @@ void parseMavlink(void) {
 void copyNewMavlinkValuesToAirlock() {
     // Mavlink is presumed to be the slower thread, and more tolerant of delays. Therefore
     // we use a large timeout for the Mutex.
-    copy_osd_state_thread_safe(&mavlink_osd_state, &airlock_osd_state, portMAX_DELAY);
+    copy_osd_state(&mavlink_osd_state, &airlock_osd_state, portMAX_DELAY);
 }
 
 void MavlinkTask(void *pvParameters) {

--- a/src/osdmavlink.c
+++ b/src/osdmavlink.c
@@ -34,6 +34,12 @@ uint8_t mavlink_requested = 0;
 extern xSemaphoreHandle onMavlinkSemaphore;
 extern uint8_t *mavlink_buffer_proc;
 
+// This is the OSD state that the Mavlink thread owns
+osd_state mavlink_osd_state = {};
+
+// This mutex controls access to the Mavlink OSD State
+xSemaphoreHandle osd_state_mavlink_mutex;
+
 void request_mavlink_rates(void) {
   const u8 MAVStreams[MAX_STREAMS] = { MAV_DATA_STREAM_RAW_SENSORS,
                                        MAV_DATA_STREAM_EXTENDED_STATUS,
@@ -50,19 +56,19 @@ void request_mavlink_rates(void) {
 //	}
   for (uint32_t i = 0; i < MAX_STREAMS; i++) {
     mavlink_msg_request_data_stream_send(MAVLINK_COMM_0,
-                                         mav_system, mav_component,
+                                         get_mav_system(), get_mav_component(),
                                          MAVStreams[i], MAVRates[i], 1);
   }
 }
 
 void request_mission_count(void) {
   mavlink_msg_mission_request_list_send(MAVLINK_COMM_0,
-                                        mav_system, mav_component);
+                                        get_mav_system(), get_mav_component());
 }
 
 void request_mission_item(uint16_t index) {
   mavlink_msg_mission_request_send(MAVLINK_COMM_0,
-                                   mav_system, mav_component, index);
+                                   get_mav_system(), get_mav_component(), index);
 }
 
 void parseMavlink(void) {
@@ -92,164 +98,169 @@ void parseMavlink(void) {
           break;
         }
 
-        mavbeat = 1;
-        mav_system    = msg.sysid;
-        mav_component = msg.compid;
-        mav_type      = mavtype;
-        autopilot = mavlink_msg_heartbeat_get_autopilot(&msg);
-        base_mode = mavlink_msg_heartbeat_get_base_mode(&msg);
-        custom_mode = mavlink_msg_heartbeat_get_custom_mode(&msg);
+        set_mavbeat(1);
+        set_mav_system(msg.sysid);
+        set_mav_component(msg.compid);
+        set_mav_type(mavtype);
+        mavlink_osd_state.autopilot = mavlink_msg_heartbeat_get_autopilot(&msg);
+        mavlink_osd_state.base_mode = mavlink_msg_heartbeat_get_base_mode(&msg);
+        mavlink_osd_state.custom_mode = mavlink_msg_heartbeat_get_custom_mode(&msg);
 
+        mavlink_osd_state.last_motor_armed = mavlink_osd_state.motor_armed;
+        mavlink_osd_state.motor_armed = mavlink_osd_state.base_mode & (1 << 7);
 
-        last_motor_armed = motor_armed;
-        motor_armed = base_mode & (1 << 7);
-
-        if (heatbeat_start_time == 0) {
-          heatbeat_start_time = GetSystimeMS();
+        if (get_heartbeat_start_time() == 0) {
+          set_heartbeat_start_time(GetSystimeMS());
         }
 
-        if (!last_motor_armed && motor_armed) {
-          armed_start_time = GetSystimeMS();
+        if (!mavlink_osd_state.last_motor_armed && mavlink_osd_state.motor_armed) {
+          set_armed_start_time(GetSystimeMS());
         }
 
-        if (last_motor_armed && !motor_armed) {
-          total_armed_time = GetSystimeMS() - armed_start_time + total_armed_time;
-          armed_start_time = 0;
+        if (mavlink_osd_state.last_motor_armed && !mavlink_osd_state.motor_armed) {
+          set_total_armed_time(GetSystimeMS() - get_armed_start_time() + get_total_armed_time());
+          set_armed_start_time(0);
         }
 
-        lastMAVBeat = GetSystimeMS();
-        if (waitingMAVBeats == 1) {
-          enable_mav_request = 1;
+        set_lastMAVBeat(GetSystimeMS());
+        if (get_waitingMAVBeats() == 1) {
+          set_enable_mav_request(1);
         }
 
-        if ((got_mission_counts == 0) && (enable_mission_count_request == 0))
+        // If we've never gotten mission_counts, and we aren't currently asking for them, 
+        // request the mission_count
+        if ((mavlink_osd_state.got_mission_counts == 0) && (mavlink_osd_state.enable_mission_count_request == 0))
         {
-          enable_mission_count_request = 1;
+          mavlink_osd_state.enable_mission_count_request = 1;
         }
       }
       break;
       case MAVLINK_MSG_ID_SYS_STATUS:
       {
-        osd_vbat_A = (mavlink_msg_sys_status_get_voltage_battery(&msg) / 1000.0f);                 //Battery voltage, in millivolts (1 = 1 millivolt)
-        osd_curr_A = mavlink_msg_sys_status_get_current_battery(&msg);                 //Battery current, in 10*milliamperes (1 = 10 milliampere)
-        osd_battery_remaining_A = mavlink_msg_sys_status_get_battery_remaining(&msg);                 //Remaining battery energy: (0%: 0, 100%: 100)
+        mavlink_osd_state.osd_vbat_A = (mavlink_msg_sys_status_get_voltage_battery(&msg) / 1000.0f);                 //Battery voltage, in millivolts (1 = 1 millivolt)
+        mavlink_osd_state.osd_curr_A = mavlink_msg_sys_status_get_current_battery(&msg);                 //Battery current, in 10*milliamperes (1 = 10 milliampere)
+        mavlink_osd_state.osd_battery_remaining_A = mavlink_msg_sys_status_get_battery_remaining(&msg);                 //Remaining battery energy: (0%: 0, 100%: 100)
         //custom_mode = mav_component;//Debug
         //osd_nav_mode = mav_system;//Debug
       }
       break;
       case MAVLINK_MSG_ID_GPS_RAW_INT:
       {
-        osd_lat = mavlink_msg_gps_raw_int_get_lat(&msg);
-        osd_lon = mavlink_msg_gps_raw_int_get_lon(&msg);
-        osd_fix_type = mavlink_msg_gps_raw_int_get_fix_type(&msg);
-        osd_hdop = mavlink_msg_gps_raw_int_get_eph(&msg);
-        osd_satellites_visible = mavlink_msg_gps_raw_int_get_satellites_visible(&msg);
+        float osd_lat_new = mavlink_msg_gps_raw_int_get_lat(&msg);
+        float osd_lon_new = mavlink_msg_gps_raw_int_get_lon(&msg);
+        
+        mavlink_osd_state.osd_lat = osd_lat_new;
+        mavlink_osd_state.osd_lon = osd_lon_new;
+        
+        mavlink_osd_state.osd_fix_type = mavlink_msg_gps_raw_int_get_fix_type(&msg);
+        mavlink_osd_state.osd_hdop = mavlink_msg_gps_raw_int_get_eph(&msg);
+        mavlink_osd_state.osd_satellites_visible = mavlink_msg_gps_raw_int_get_satellites_visible(&msg);
       }
       break;
       case MAVLINK_MSG_ID_GPS2_RAW:
       {
-        osd_lat2 = mavlink_msg_gps2_raw_get_lat(&msg);
-        osd_lon2 = mavlink_msg_gps2_raw_get_lon(&msg);
-        osd_fix_type2 = mavlink_msg_gps2_raw_get_fix_type(&msg);
-        osd_hdop2 = mavlink_msg_gps2_raw_get_eph(&msg);
-        osd_satellites_visible2 = mavlink_msg_gps2_raw_get_satellites_visible(&msg);
+        mavlink_osd_state.osd_lat2 = mavlink_msg_gps2_raw_get_lat(&msg);
+        mavlink_osd_state.osd_lon2 = mavlink_msg_gps2_raw_get_lon(&msg);
+        mavlink_osd_state.osd_fix_type2 = mavlink_msg_gps2_raw_get_fix_type(&msg);
+        mavlink_osd_state.osd_hdop2 = mavlink_msg_gps2_raw_get_eph(&msg);
+        mavlink_osd_state.osd_satellites_visible2 = mavlink_msg_gps2_raw_get_satellites_visible(&msg);
       }
       break;
       case MAVLINK_MSG_ID_VFR_HUD:
       {
-        osd_airspeed = mavlink_msg_vfr_hud_get_airspeed(&msg);
-        osd_groundspeed = mavlink_msg_vfr_hud_get_groundspeed(&msg);
-        osd_heading = mavlink_msg_vfr_hud_get_heading(&msg);                 // 0..360 deg, 0=north
-        osd_throttle = mavlink_msg_vfr_hud_get_throttle(&msg);
+        mavlink_osd_state.osd_airspeed = mavlink_msg_vfr_hud_get_airspeed(&msg);
+        mavlink_osd_state.osd_groundspeed = mavlink_msg_vfr_hud_get_groundspeed(&msg);
+        mavlink_osd_state.osd_heading = mavlink_msg_vfr_hud_get_heading(&msg);                 // 0..360 deg, 0=north
+        mavlink_osd_state.osd_throttle = mavlink_msg_vfr_hud_get_throttle(&msg);
         //if(osd_throttle > 100 && osd_throttle < 150) osd_throttle = 100;//Temporary fix for ArduPlane 2.28
         //if(osd_throttle < 0 || osd_throttle > 150) osd_throttle = 0;//Temporary fix for ArduPlane 2.28
-        osd_alt = mavlink_msg_vfr_hud_get_alt(&msg);
-        osd_climb = mavlink_msg_vfr_hud_get_climb(&msg);
+        mavlink_osd_state.osd_alt = mavlink_msg_vfr_hud_get_alt(&msg);
+        mavlink_osd_state.osd_climb = mavlink_msg_vfr_hud_get_climb(&msg);
       }
       break;
       case MAVLINK_MSG_ID_GLOBAL_POSITION_INT:                        // jmmods
       {
-        osd_rel_alt = mavlink_msg_global_position_int_get_relative_alt(&msg) / 1000.0;                    // jmmods
+        mavlink_osd_state.osd_rel_alt = mavlink_msg_global_position_int_get_relative_alt(&msg) / 1000.0;                    // jmmods
         // uav.relative_alt = packet.relative_alt / 1000.0; //jmtune Altitude above ground in meters, expressed as * 1000 (millimeters)   // jmmods
       }
       break;
 
       case MAVLINK_MSG_ID_ATTITUDE:
       {
-        osd_pitch = Rad2Deg(mavlink_msg_attitude_get_pitch(&msg));
-        osd_roll = Rad2Deg(mavlink_msg_attitude_get_roll(&msg));
-        osd_yaw = Rad2Deg(mavlink_msg_attitude_get_yaw(&msg));
+        mavlink_osd_state.osd_pitch = Rad2Deg(mavlink_msg_attitude_get_pitch(&msg));
+        mavlink_osd_state.osd_roll = Rad2Deg(mavlink_msg_attitude_get_roll(&msg));
+        mavlink_osd_state.osd_yaw = Rad2Deg(mavlink_msg_attitude_get_yaw(&msg));
       }
       break;
       case MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT:
       {
-        nav_roll = mavlink_msg_nav_controller_output_get_nav_roll(&msg);
-        nav_pitch = mavlink_msg_nav_controller_output_get_nav_pitch(&msg);
-        nav_bearing = mavlink_msg_nav_controller_output_get_nav_bearing(&msg);
-        wp_target_bearing = mavlink_msg_nav_controller_output_get_target_bearing(&msg);
-        wp_dist = mavlink_msg_nav_controller_output_get_wp_dist(&msg);
-        alt_error = mavlink_msg_nav_controller_output_get_alt_error(&msg);
-        aspd_error = mavlink_msg_nav_controller_output_get_aspd_error(&msg);
-        xtrack_error = mavlink_msg_nav_controller_output_get_xtrack_error(&msg);
+        mavlink_osd_state.nav_roll = mavlink_msg_nav_controller_output_get_nav_roll(&msg);
+        mavlink_osd_state.nav_pitch = mavlink_msg_nav_controller_output_get_nav_pitch(&msg);
+        mavlink_osd_state.nav_bearing = mavlink_msg_nav_controller_output_get_nav_bearing(&msg);
+        mavlink_osd_state.wp_target_bearing = mavlink_msg_nav_controller_output_get_target_bearing(&msg);
+        mavlink_osd_state.wp_dist = mavlink_msg_nav_controller_output_get_wp_dist(&msg);
+        mavlink_osd_state.alt_error = mavlink_msg_nav_controller_output_get_alt_error(&msg);
+        mavlink_osd_state.aspd_error = mavlink_msg_nav_controller_output_get_aspd_error(&msg);
+        mavlink_osd_state.xtrack_error = mavlink_msg_nav_controller_output_get_xtrack_error(&msg);
       }
       break;
       case MAVLINK_MSG_ID_MISSION_CURRENT:
       {
-        wp_number = (uint8_t)mavlink_msg_mission_current_get_seq(&msg);
+        mavlink_osd_state.wp_number = (uint8_t)mavlink_msg_mission_current_get_seq(&msg);
       }
       break;
       case MAVLINK_MSG_ID_RC_CHANNELS_RAW:
       {
-        if (!osd_chan_cnt_above_eight)
+        if (!mavlink_osd_state.osd_chan_cnt_above_eight)
         {
-          osd_chan1_raw = mavlink_msg_rc_channels_raw_get_chan1_raw(&msg);
-          osd_chan2_raw = mavlink_msg_rc_channels_raw_get_chan2_raw(&msg);
-          osd_chan3_raw = mavlink_msg_rc_channels_raw_get_chan3_raw(&msg);
-          osd_chan4_raw = mavlink_msg_rc_channels_raw_get_chan4_raw(&msg);
-          osd_chan5_raw = mavlink_msg_rc_channels_raw_get_chan5_raw(&msg);
-          osd_chan6_raw = mavlink_msg_rc_channels_raw_get_chan6_raw(&msg);
-          osd_chan7_raw = mavlink_msg_rc_channels_raw_get_chan7_raw(&msg);
-          osd_chan8_raw = mavlink_msg_rc_channels_raw_get_chan8_raw(&msg);
-          osd_rssi = mavlink_msg_rc_channels_raw_get_rssi(&msg);
+          mavlink_osd_state.osd_chan1_raw = mavlink_msg_rc_channels_raw_get_chan1_raw(&msg);
+          mavlink_osd_state.osd_chan2_raw = mavlink_msg_rc_channels_raw_get_chan2_raw(&msg);
+          mavlink_osd_state.osd_chan3_raw = mavlink_msg_rc_channels_raw_get_chan3_raw(&msg);
+          mavlink_osd_state.osd_chan4_raw = mavlink_msg_rc_channels_raw_get_chan4_raw(&msg);
+          mavlink_osd_state.osd_chan5_raw = mavlink_msg_rc_channels_raw_get_chan5_raw(&msg);
+          mavlink_osd_state.osd_chan6_raw = mavlink_msg_rc_channels_raw_get_chan6_raw(&msg);
+          mavlink_osd_state.osd_chan7_raw = mavlink_msg_rc_channels_raw_get_chan7_raw(&msg);
+          mavlink_osd_state.osd_chan8_raw = mavlink_msg_rc_channels_raw_get_chan8_raw(&msg);
+          mavlink_osd_state.osd_rssi = mavlink_msg_rc_channels_raw_get_rssi(&msg);
         }
       }
       break;
       case MAVLINK_MSG_ID_RC_CHANNELS:
       {
-        osd_chan_cnt_above_eight = true;
-        osd_chan1_raw = mavlink_msg_rc_channels_get_chan1_raw(&msg);
-        osd_chan2_raw = mavlink_msg_rc_channels_get_chan2_raw(&msg);
-        osd_chan3_raw = mavlink_msg_rc_channels_get_chan3_raw(&msg);
-        osd_chan4_raw = mavlink_msg_rc_channels_get_chan4_raw(&msg);
-        osd_chan5_raw = mavlink_msg_rc_channels_get_chan5_raw(&msg);
-        osd_chan6_raw = mavlink_msg_rc_channels_get_chan6_raw(&msg);
-        osd_chan7_raw = mavlink_msg_rc_channels_get_chan7_raw(&msg);
-        osd_chan8_raw = mavlink_msg_rc_channels_get_chan8_raw(&msg);
-        osd_chan9_raw = mavlink_msg_rc_channels_get_chan9_raw(&msg);
-        osd_chan10_raw = mavlink_msg_rc_channels_get_chan10_raw(&msg);
-        osd_chan11_raw = mavlink_msg_rc_channels_get_chan11_raw(&msg);
-        osd_chan12_raw = mavlink_msg_rc_channels_get_chan12_raw(&msg);
-        osd_chan13_raw = mavlink_msg_rc_channels_get_chan13_raw(&msg);
-        osd_chan14_raw = mavlink_msg_rc_channels_get_chan14_raw(&msg);
-        osd_chan15_raw = mavlink_msg_rc_channels_get_chan15_raw(&msg);
-        osd_chan16_raw = mavlink_msg_rc_channels_get_chan16_raw(&msg);
-        osd_rssi = mavlink_msg_rc_channels_get_rssi(&msg);
+        mavlink_osd_state.osd_chan_cnt_above_eight = true;
+        mavlink_osd_state.osd_chan1_raw = mavlink_msg_rc_channels_get_chan1_raw(&msg);
+        mavlink_osd_state.osd_chan2_raw = mavlink_msg_rc_channels_get_chan2_raw(&msg);
+        mavlink_osd_state.osd_chan3_raw = mavlink_msg_rc_channels_get_chan3_raw(&msg);
+        mavlink_osd_state.osd_chan4_raw = mavlink_msg_rc_channels_get_chan4_raw(&msg);
+        mavlink_osd_state.osd_chan5_raw = mavlink_msg_rc_channels_get_chan5_raw(&msg);
+        mavlink_osd_state.osd_chan6_raw = mavlink_msg_rc_channels_get_chan6_raw(&msg);
+        mavlink_osd_state.osd_chan7_raw = mavlink_msg_rc_channels_get_chan7_raw(&msg);
+        mavlink_osd_state.osd_chan8_raw = mavlink_msg_rc_channels_get_chan8_raw(&msg);
+        mavlink_osd_state.osd_chan9_raw = mavlink_msg_rc_channels_get_chan9_raw(&msg);
+        mavlink_osd_state.osd_chan10_raw = mavlink_msg_rc_channels_get_chan10_raw(&msg);
+        mavlink_osd_state.osd_chan11_raw = mavlink_msg_rc_channels_get_chan11_raw(&msg);
+        mavlink_osd_state.osd_chan12_raw = mavlink_msg_rc_channels_get_chan12_raw(&msg);
+        mavlink_osd_state.osd_chan13_raw = mavlink_msg_rc_channels_get_chan13_raw(&msg);
+        mavlink_osd_state.osd_chan14_raw = mavlink_msg_rc_channels_get_chan14_raw(&msg);
+        mavlink_osd_state.osd_chan15_raw = mavlink_msg_rc_channels_get_chan15_raw(&msg);
+        mavlink_osd_state.osd_chan16_raw = mavlink_msg_rc_channels_get_chan16_raw(&msg);
+        mavlink_osd_state.osd_rssi = mavlink_msg_rc_channels_get_rssi(&msg);
       }
       break;
       case MAVLINK_MSG_ID_WIND:
       {
-        osd_windDir = mavlink_msg_wind_get_direction(&msg);                 // 0..360 deg, 0=north
-        osd_windSpeed = mavlink_msg_wind_get_speed(&msg);                 //m/s
+        mavlink_osd_state.osd_windDir = mavlink_msg_wind_get_direction(&msg);                 // 0..360 deg, 0=north
+        mavlink_osd_state.osd_windSpeed = mavlink_msg_wind_get_speed(&msg);                 //m/s
       }
       break;
-
+      
       case MAVLINK_MSG_ID_MISSION_COUNT:
       {
-        mission_counts = mavlink_msg_mission_count_get_count(&msg);
-        got_mission_counts = 1;
-        enable_mission_item_request = 1;
-        current_mission_item_req_index = 0;
-        wp_counts = 0;
+        mavlink_osd_state.mission_counts = mavlink_msg_mission_count_get_count(&msg);
+        mavlink_osd_state.got_mission_counts = 1;
+        mavlink_osd_state.enable_mission_item_request = 1;
+        mavlink_osd_state.current_mission_item_req_index = 0;
+        mavlink_osd_state.wp_counts = 0;
       }
       break;
 
@@ -261,26 +272,26 @@ void parseMavlink(void) {
         cmd = mavlink_msg_mission_item_get_command(&msg);
 
         // received a packet, but not what we requested
-        if (current_mission_item_req_index == seq)
+        if (mavlink_osd_state.current_mission_item_req_index == seq)
         {
           //store the waypoints
-          if ((cmd == MAV_CMD_NAV_WAYPOINT) && (wp_counts < MAX_WAYPOINTS))
+          if ((cmd == MAV_CMD_NAV_WAYPOINT) && (mavlink_osd_state.wp_counts < MAX_WAYPOINTS))
           {
-            wp_list[wp_counts].seq = seq;
-            wp_list[wp_counts].cmd = cmd;
+            mavlink_osd_state.wp_list[mavlink_osd_state.wp_counts].seq = seq;
+            mavlink_osd_state.wp_list[mavlink_osd_state.wp_counts].cmd = cmd;
 
-            wp_list[wp_counts].x = mavlink_msg_mission_item_get_x(&msg);
-            wp_list[wp_counts].y = mavlink_msg_mission_item_get_y(&msg);
-            wp_list[wp_counts].z = mavlink_msg_mission_item_get_z(&msg);
+            mavlink_osd_state.wp_list[mavlink_osd_state.wp_counts].x = mavlink_msg_mission_item_get_x(&msg);
+            mavlink_osd_state.wp_list[mavlink_osd_state.wp_counts].y = mavlink_msg_mission_item_get_y(&msg);
+            mavlink_osd_state.wp_list[mavlink_osd_state.wp_counts].z = mavlink_msg_mission_item_get_z(&msg);
 
-            wp_list[wp_counts].current = mavlink_msg_mission_item_get_current(&msg);
-            wp_counts++;
+            mavlink_osd_state.wp_list[mavlink_osd_state.wp_counts].current = mavlink_msg_mission_item_get_current(&msg);
+            mavlink_osd_state.wp_counts++;
           }
 
-          current_mission_item_req_index++;
-          if (current_mission_item_req_index >= mission_counts) {
-            enable_mission_item_request = 0;
-            got_all_wps = 1;
+          mavlink_osd_state.current_mission_item_req_index++;
+          if (mavlink_osd_state.current_mission_item_req_index >= mavlink_osd_state.mission_counts) {
+            mavlink_osd_state.enable_mission_item_request = 0;
+            mavlink_osd_state.got_all_wps = 1;
           }
         }
 
@@ -306,13 +317,32 @@ void parseMavlink(void) {
   }
 }
 
+void copyNewMavlinkValuesToAirlock() {
+    // Mavlink is presumed to be the slower thread, and more tolerant of delays. Therefore
+    // we use a large timeout for the Mutex.
+    copy_osd_state_thread_safe(&mavlink_osd_state, &airlock_osd_state, portMAX_DELAY);
+}
+
 void MavlinkTask(void *pvParameters) {
+  clear_osd_state_struct(&mavlink_osd_state);
   mavlink_usart_init(get_map_bandrate(eeprom_buffer.params.uart_bandrate));    // jmmods 19200 for ultimate lrs use
-  sys_start_time = GetSystimeMS();
+  set_sys_start_time(GetSystimeMS());
 
   while (1)
   {
+    // Take event semaphore
     xSemaphoreTake(onMavlinkSemaphore, portMAX_DELAY);
-    parseMavlink();
+    // Lock access to Mavlink OSDState via mutex
+    if (xSemaphoreTake(osd_state_mavlink_mutex, portMAX_DELAY) == pdTRUE ) {
+
+        // Do Mavlink parsing from serial input
+        parseMavlink();
+        // Copy updated values into the airlock
+        copyNewMavlinkValuesToAirlock();
+
+        // Release the Mavlink OSDState mutex
+        xSemaphoreGive(osd_state_mavlink_mutex);
+    }   
+    // At this point Mavlink OSDState mutex is briefly open for access by others (i.e. Board.c)
   }
 }

--- a/src/osdproc.c
+++ b/src/osdproc.c
@@ -34,6 +34,14 @@
 
 extern xSemaphoreHandle onScreenDisplaySemaphore;
 
+extern xSemaphoreHandle osd_state_adhoc_mutex;
+
+// This is the OSD state that the OSDProc thread owns
+osd_state osdproc_osd_state = {};
+
+// This mutex controls access to the OSDProc OSD State
+xSemaphoreHandle osd_state_osdproc_mutex;
+
 int32_t test_alt, test_speed, test_throttle;
 
 //2:small, 0:normal, 3:large
@@ -152,33 +160,86 @@ void do_converts(void) {
 }
 
 bool shownAtPanel(uint16_t itemPanel) {
-  //issue #1 - fixed
-  return ((itemPanel & (1 << (current_panel - 1))) != 0);
+  bool result = false;
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      //issue #1 - fixed
+      result = ((itemPanel & (1 << (adhoc_osd_state.current_panel - 1))) != 0);
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return result;
 }
 
 bool enabledAndShownOnPanel(uint16_t enabled, uint16_t panel) {
   return enabled == 1 && shownAtPanel(panel);
 }
 
+void copyNewAirlockValuesToOsdProc() {
+    // Considered using a deliberately short delay here, but it seems ok this way.
+    copy_osd_state_thread_safe(&airlock_osd_state, &osdproc_osd_state, portMAX_DELAY);
+}
+
+void getOsdXandYOffsets(int8_t * p_osd_offset_X, int8_t * p_osd_offset_Y) {
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      // Get the OSD offsets
+      *p_osd_offset_X = adhoc_osd_state.osd_offset_X;
+      *p_osd_offset_Y = adhoc_osd_state.osd_offset_Y;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }        
+}
+
+void setOsdOffsets(){
+  int8_t TEMP_osd_offset_X;
+  int8_t TEMP_osd_offset_Y;  
+  
+  getOsdXandYOffsets(&TEMP_osd_offset_X, &TEMP_osd_offset_Y);  
+  
+  osdVideoSetXOffset(TEMP_osd_offset_X);
+  osdVideoSetYOffset(TEMP_osd_offset_Y); 
+}
+
 void vTaskOSD(void *pvParameters) {
+    
+  clear_osd_state_struct(&osdproc_osd_state);    
+    
   uav3D_init();
   uav2D_init();
   simple_attitude_init();
   home_direction_init();
 
-  osdVideoSetXOffset(osd_offset_X);
-  osdVideoSetYOffset(osd_offset_Y);
-
+  setOsdOffsets();  
   osdCoreInit();
 
-  for (;; )
+  while (1)
   {
     xSemaphoreTake(onScreenDisplaySemaphore, portMAX_DELAY);
+    
+    // Lock access to OSDProc OSD state via mutex
+    if (xSemaphoreTake(osd_state_osdproc_mutex, portMAX_DELAY) == pdTRUE ) {
+    
+        copyNewAirlockValuesToOsdProc();
+        clearGraphics();
+        RenderScreen();
 
-    clearGraphics();
-
-    RenderScreen();
+        // Release the Mavlink OSDState mutex
+        xSemaphoreGive(osd_state_osdproc_mutex);
+    }
+    // At this point OSDProc OSDState mutex is briefly open for access by others, should
+    // they need it. 
   }
+}
+
+void resetPanelNumberIfBadPanelValue(){
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      // Reset panel to #1 if the panel number is out of range
+      if (adhoc_osd_state.current_panel < 1 || adhoc_osd_state.current_panel > eeprom_buffer.params.Max_panels) {
+        adhoc_osd_state.current_panel = 1;
+      }
+      // Release the ad-hoc mutex
+      xSemaphoreGive(osd_state_adhoc_mutex);
+    }  
 }
 
 // TODO: try if this is performance critical or not
@@ -188,9 +249,7 @@ char* tmp_str1 = "";
 void RenderScreen(void) {
   do_converts();
 
-  if (current_panel > eeprom_buffer.params.Max_panels) {
-    current_panel = 1;
-  }
+  resetPanelNumberIfBadPanelValue();
 
   set_home_position_if_unset();
   set_home_altitude_if_unset();
@@ -243,6 +302,17 @@ void RenderScreen(void) {
   draw_version_splash();
 }
 
+int get_map_radius() {
+  int map_radius = 0;
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      map_radius = (int)(eeprom_buffer.params.Atti_3D_map_radius * adhoc_osd_state.atti_3d_scale);
+      // Release the ad-hoc mutex
+      xSemaphoreGive(osd_state_adhoc_mutex);
+   }
+      
+   return map_radius;
+}
+
 void draw_uav3d(void) {
   if (!enabledAndShownOnPanel(eeprom_buffer.params.Atti_3D_en,
                               eeprom_buffer.params.Atti_3D_panel)) {
@@ -256,20 +326,20 @@ void draw_uav3d(void) {
   static int32_t yaw = 0;
   int x = eeprom_buffer.params.Atti_3D_posX;
   int y = eeprom_buffer.params.Atti_3D_posY;
-  int map_radius = (int)(eeprom_buffer.params.Atti_3D_map_radius * atti_3d_scale);
+  int map_radius = get_map_radius();
 
   write_string("N", x, y - map_radius, 0, 0, TEXT_VA_TOP, TEXT_HA_CENTER, 0, SIZE_TO_FONT[0]);
   write_string("E", x + map_radius, y, 0, 0, TEXT_VA_MIDDLE, TEXT_HA_CENTER, 0, SIZE_TO_FONT[0]);
   //need to adjust viewport base on the video mode
   Adjust_Viewport_CAM4DV1(&cam, GRAPHICS_RIGHT, GRAPHICS_BOTTOM);
 
-  roll = ((int32_t)osd_roll + 360) % 360;
+  roll = ((int32_t)osdproc_osd_state.osd_roll + 360) % 360;
   roll = fabs(roll - 360);
 
-  pitch = ((int32_t)osd_pitch + 360) % 360;
+  pitch = ((int32_t)osdproc_osd_state.osd_pitch + 360) % 360;
   pitch = fabs(pitch - 360);
 
-  yaw = fabs(osd_heading - 360);
+  yaw = fabs(osdproc_osd_state.osd_heading - 360);
 
   Reset_OBJECT4DV1(&uav3D);
 
@@ -322,9 +392,9 @@ void draw_uav3d(void) {
 
 void draw_simple_attitude() {
   Reset_Polygon2D(&simple_attitude);
-  int pitch = osd_pitch;
+  int pitch = osdproc_osd_state.osd_pitch;
   const int max_pitch = 60;
-  const int radius = 4 * atti_mp_scale;
+  const int radius = 4 * get_atti_mp_scale();
   const int x = simple_attitude.x0;
   const int y = simple_attitude.y0;
   if (pitch > max_pitch) {
@@ -338,7 +408,7 @@ void draw_simple_attitude() {
   write_line_outlined(x, y - radius - 1, x, y - 2 * radius, 0, 0, 0, 1);
   write_circle_outlined(x, y, radius, 0, 1, 0, 1);
 
-  Transform_Polygon2D(&simple_attitude, -osd_roll, 0, pitch);
+  Transform_Polygon2D(&simple_attitude, -osdproc_osd_state.osd_roll, 0, pitch);
   VECTOR4D v;
   for (int i = 0; i < simple_attitude.num_verts; i += 2) {
     write_line_outlined(simple_attitude.vlist_trans[i].x + x, simple_attitude.vlist_trans[i].y + y,
@@ -352,7 +422,7 @@ void draw_radar() {
   int index = 0;
 
   Reset_Polygon2D(&uav2D);
-  Transform_Polygon2D(&uav2D, -osd_roll, 0, osd_pitch);
+  Transform_Polygon2D(&uav2D, -osdproc_osd_state.osd_roll, 0, osdproc_osd_state.osd_pitch);
 
   // loop thru and draw a line from vertices 1 to n
   VECTOR4D v;
@@ -369,7 +439,7 @@ void draw_radar() {
 
   //rotate roll scale and display, we only cal x
   Reset_Polygon2D(&rollscale2D);
-  Rotate_Polygon2D(&rollscale2D, -osd_roll);
+  Rotate_Polygon2D(&rollscale2D, -osdproc_osd_state.osd_roll);
   for (index = 0; index < rollscale2D.num_verts - 1; index++)
   {
     // draw line from ith to ith+1 vertex
@@ -380,8 +450,9 @@ void draw_radar() {
 
   int x = eeprom_buffer.params.Atti_mp_posX;
   int y = eeprom_buffer.params.Atti_mp_posY;
-  int wingStart = (int)(12.0f * atti_mp_scale);
-  int wingEnd = (int)(7.0f * atti_mp_scale);
+  float TEMP_atti_mp_scale = get_atti_mp_scale();
+  int wingStart = (int)(12.0f * TEMP_atti_mp_scale);
+  int wingEnd = (int)(7.0f * TEMP_atti_mp_scale);
   char tmp_str[10] = { 0 };
   //draw uav
   write_line_outlined(x, y, x - 9, y + 5, 2, 2, 0, 1);
@@ -391,30 +462,31 @@ void draw_radar() {
 
 
   write_filled_rectangle_lm(x - 9, y + 6, 15, 9, 0, 1);
-  sprintf(tmp_str, "%d", (int)osd_pitch);
+  sprintf(tmp_str, "%d", (int)osdproc_osd_state.osd_pitch);
   write_string(tmp_str, x, y + 5, 0, 0, TEXT_VA_TOP, TEXT_HA_CENTER, 0, SIZE_TO_FONT[0]);
 
-  y = eeprom_buffer.params.Atti_mp_posY - (int)(38.0f * atti_mp_scale);
+  y = eeprom_buffer.params.Atti_mp_posY - (int)(38.0f * TEMP_atti_mp_scale);
   //draw roll value
   write_line_outlined(x, y, x - 4, y + 8, 2, 2, 0, 1);
   write_line_outlined(x, y, x + 4, y + 8, 2, 2, 0, 1);
   write_line_outlined(x - 4, y + 8, x + 4, y + 8, 2, 2, 0, 1);
-  sprintf(tmp_str, "%d", (int)osd_roll);
+  sprintf(tmp_str, "%d", (int)osdproc_osd_state.osd_roll);
   write_string(tmp_str, x, y - 3, 0, 0, TEXT_VA_BOTTOM, TEXT_HA_CENTER, 0, SIZE_TO_FONT[0]);
 }
 
+/*
 void draw_home_direction_debug_info(int x, int y, float bearing)
 {
   // Debug output for direction to home calculation
   char tmp_str[15] = { 0 };
   sprintf(tmp_str, "b %d", (int32_t)bearing);
   write_string(tmp_str, x, y + 15, 0, 0, TEXT_VA_TOP, TEXT_HA_RIGHT, 0, SIZE_TO_FONT[1]);
-  sprintf(tmp_str, "ohb %d", (int32_t)osd_home_bearing);
+  sprintf(tmp_str, "ohb %d", (int32_t)get_osd_home_bearing());
   write_string(tmp_str, x, y + 30, 0, 0, TEXT_VA_TOP, TEXT_HA_RIGHT, 0, SIZE_TO_FONT[1]);
-  sprintf(tmp_str, "oh %d", (int32_t)osd_heading);
-  write_string(tmp_str, x, y + 45, 0, 0, TEXT_VA_TOP, TEXT_HA_RIGHT, 0, SIZE_TO_FONT[1]);
+  sprintf(tmp_str, "oh %d", (int32_t)osdproc_osd_state.osd_heading);
+  write_string(tmp_str, x, y + 45, 0, 0, TEXT_VA_TOP, TEXT_HA_RIGHT, 0, SIZE_TO_FONT[1]);  
 }
-
+*/
 
 void draw_home_direction() {
   if (!enabledAndShownOnPanel(eeprom_buffer.params.HomeDirection_enabled,
@@ -425,8 +497,9 @@ void draw_home_direction() {
   // Bearing to home should consistently show 0 degrees (north) until 
   // home position is actually set
   float bearing = 0.0f;
-  if (osd_got_home == 1) {
-      bearing = osd_home_bearing - osd_heading;
+  int got_home = get_osd_got_home();
+  if (got_home == 1) {
+      bearing = get_osd_home_bearing() - osdproc_osd_state.osd_heading;
   }
   
   Reset_Polygon2D(&home_direction);
@@ -438,16 +511,16 @@ void draw_home_direction() {
   const int y = home_direction.y0;
 
   // Only fill in interior if home has been set
-  if (osd_got_home == 1) {
+  if (got_home == 1) {
       for (int i = 0; i < home_direction.num_verts; i += 2) {
         write_line_lm(home_direction.vlist_trans[i].x + x,
                       home_direction.vlist_trans[i].y + y,
                       home_direction.vlist_trans[i + 1].x + x,
                       home_direction.vlist_trans[i + 1].y + y,
                       1, 1);
-      }
-  }
-  
+      }      
+  }  
+
   // Always show the outline
   for (int i = 0; i < home_direction.num_verts; i += 2) {
     write_line_lm(home_direction_outline.vlist_trans[i].x + x,
@@ -486,15 +559,15 @@ void draw_throttle(void) {
   posX = eeprom_buffer.params.Throt_posX;
   posY = eeprom_buffer.params.Throt_posY;
 
-  pos_th_y = (int16_t)(0.5 * osd_throttle);
+  pos_th_y = (int16_t)(0.5 * osdproc_osd_state.osd_throttle);
   pos_th_x = posX - 25 + pos_th_y;
-  sprintf(tmp_str, "%d%%", (int32_t)osd_throttle);
+  sprintf(tmp_str, "%d%%", (int32_t)osdproc_osd_state.osd_throttle);
   write_string(tmp_str, posX, posY, 0, 0, TEXT_VA_TOP, TEXT_HA_RIGHT, 0, SIZE_TO_FONT[0]);
 
   if (eeprom_buffer.params.Throt_scale_en) {
-    pos_th_y = (int16_t)(0.5 * osd_throttle);
+    pos_th_y = (int16_t)(0.5 * osdproc_osd_state.osd_throttle);
     pos_th_x = posX - 25 + pos_th_y;
-    sprintf(tmp_str, "%d%%", (int32_t)osd_throttle);
+    sprintf(tmp_str, "%d%%", (int32_t)osdproc_osd_state.osd_throttle);
     write_string(tmp_str, posX, posY, 0, 0, TEXT_VA_TOP, TEXT_HA_RIGHT, 0, SIZE_TO_FONT[0]);
     if (eeprom_buffer.params.Throttle_Scale_Type == 0) {
       write_filled_rectangle_lm(posX + 3, posY + 25 - pos_th_y, 5, pos_th_y, 1, 1);
@@ -511,8 +584,8 @@ void draw_throttle(void) {
       write_vline_lm(posX - 25, posY + 10, posY + 14, 1, 1);
     }
   } else {
-    pos_th_y = (int16_t)(0.5 * osd_throttle);
-    sprintf(tmp_str, "THR %d%%", (int32_t)osd_throttle);
+    pos_th_y = (int16_t)(0.5 * osdproc_osd_state.osd_throttle);
+    sprintf(tmp_str, "THR %d%%", (int32_t)osdproc_osd_state.osd_throttle);
     write_string(tmp_str, posX, posY, 0, 0, TEXT_VA_TOP, TEXT_HA_RIGHT, 0, SIZE_TO_FONT[0]);
   }
 }
@@ -523,6 +596,8 @@ void draw_home_latitude() {
     return;
   }
 
+  float osd_home_lat = get_osd_home_lat();
+  
   sprintf(tmp_str, "H %0.5f", (double) osd_home_lat / DEGREE_MULTIPLIER);
   write_string(tmp_str, eeprom_buffer.params.HomeLatitude_posX,
                eeprom_buffer.params.HomeLatitude_posY, 0, 0, TEXT_VA_TOP,
@@ -536,6 +611,8 @@ void draw_home_longitude() {
     return;
   }
 
+  float osd_home_lon = get_osd_home_lon();
+  
   sprintf(tmp_str, "H %0.5f", (double) osd_home_lon / DEGREE_MULTIPLIER);
   write_string(tmp_str, eeprom_buffer.params.HomeLongitude_posX,
                eeprom_buffer.params.HomeLongitude_posY, 0, 0, TEXT_VA_TOP,
@@ -549,7 +626,7 @@ void draw_gps_status() {
     return;
   }
 
-  switch (osd_fix_type) {
+  switch (osdproc_osd_state.osd_fix_type) {
   case NO_GPS:
     // Only show this message when in fact there is no GPS attached
     sprintf(tmp_str, "NOGPS");
@@ -558,29 +635,29 @@ void draw_gps_status() {
     sprintf(tmp_str, "NOFIX");
     break;
   case GPS_OK_FIX_2D:
-    sprintf(tmp_str, "2D-%d", (int) osd_satellites_visible);
+    sprintf(tmp_str, "2D-%d", (int) osdproc_osd_state.osd_satellites_visible);
     break;
   case GPS_OK_FIX_3D:
-    sprintf(tmp_str, "3D-%d", (int) osd_satellites_visible);
+    sprintf(tmp_str, "3D-%d", (int) osdproc_osd_state.osd_satellites_visible);
     break;
   case GPS_OK_FIX_3D_DGPS:
-    sprintf(tmp_str, "D3D-%d", (int) osd_satellites_visible);
+    sprintf(tmp_str, "D3D-%d", (int) osdproc_osd_state.osd_satellites_visible);
     break;    
   // I don't expect users will ever see these in the real world, but let's
   // handle them anyway
   case GPS_OK_FIX_3D_RTK_FLOAT:
-    sprintf(tmp_str, "RTK-%d", (int) osd_satellites_visible);
+    sprintf(tmp_str, "RTK-%d", (int) osdproc_osd_state.osd_satellites_visible);
     break;    
   case GPS_OK_FIX_TYPE_RTK_FIXED:
-    sprintf(tmp_str, "RTKF-%d", (int) osd_satellites_visible);
+    sprintf(tmp_str, "RTKF-%d", (int) osdproc_osd_state.osd_satellites_visible);
     break;    
   case GPS_OK_FIX_TYPE_STATIC:
-    sprintf(tmp_str, "STAT-%d", (int) osd_satellites_visible);
+    sprintf(tmp_str, "STAT-%d", (int) osdproc_osd_state.osd_satellites_visible);
     break;
   default:
     // Some unknown GPS status, do our best to show we don't understand it in the 
     // tiny space allowed, showing fix code and number of satellites locked
-    sprintf(tmp_str, "?FT:%d-%d", (int) osd_fix_type, (int) osd_satellites_visible);
+    sprintf(tmp_str, "?FT:%d-%d", (int) osdproc_osd_state.osd_fix_type, (int) osdproc_osd_state.osd_satellites_visible);
     break;
   }
   write_string(tmp_str, eeprom_buffer.params.GpsStatus_posX,
@@ -595,7 +672,7 @@ void draw_gps_hdop() {
     return;
   }
 
-  sprintf(tmp_str, "HDOP %0.1f", (double) osd_hdop / 100.0f);
+  sprintf(tmp_str, "HDOP %0.1f", (double) osdproc_osd_state.osd_hdop / 100.0f);
   write_string(tmp_str, eeprom_buffer.params.GpsHDOP_posX,
                eeprom_buffer.params.GpsHDOP_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.GpsHDOP_align, 0,
@@ -607,8 +684,8 @@ void draw_gps_latitude() {
                               eeprom_buffer.params.GpsLat_panel)) {
     return;
   }
-
-  sprintf(tmp_str, "%0.5f", (double) osd_lat / DEGREE_MULTIPLIER);
+  
+  sprintf(tmp_str, "%0.5f", (double) osdproc_osd_state.osd_lat / DEGREE_MULTIPLIER);
   write_string(tmp_str, eeprom_buffer.params.GpsLat_posX,
                eeprom_buffer.params.GpsLat_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.GpsLat_align, 0,
@@ -619,9 +696,9 @@ void draw_gps_longitude() {
   if (!enabledAndShownOnPanel(eeprom_buffer.params.GpsLon_en,
                               eeprom_buffer.params.GpsLon_panel)) {
     return;
-  }
+  } 
 
-  sprintf(tmp_str, "%0.5f", (double) osd_lon / DEGREE_MULTIPLIER);
+  sprintf(tmp_str, "%0.5f", (double) osdproc_osd_state.osd_lon / DEGREE_MULTIPLIER);
   write_string(tmp_str, eeprom_buffer.params.GpsLon_posX,
                eeprom_buffer.params.GpsLon_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.GpsLon_align, 0,
@@ -634,19 +711,19 @@ void draw_gps2_status() {
     return;
   }
 
-  switch (osd_fix_type2) {
+  switch (osdproc_osd_state.osd_fix_type2) {
   case NO_GPS:
   case NO_FIX:
     sprintf(tmp_str, "NOFIX");
     break;
   case GPS_OK_FIX_2D:
-    sprintf(tmp_str, "2D-%d", (int) osd_satellites_visible2);
+    sprintf(tmp_str, "2D-%d", (int) osdproc_osd_state.osd_satellites_visible2);
     break;
   case GPS_OK_FIX_3D:
-    sprintf(tmp_str, "3D-%d", (int) osd_satellites_visible2);
+    sprintf(tmp_str, "3D-%d", (int) osdproc_osd_state.osd_satellites_visible2);
     break;
   case GPS_OK_FIX_3D_DGPS:
-    sprintf(tmp_str, "D3D-%d", (int) osd_satellites_visible2);
+    sprintf(tmp_str, "D3D-%d", (int) osdproc_osd_state.osd_satellites_visible2);
     break;
   default:
     sprintf(tmp_str, "NOGPS");
@@ -664,7 +741,7 @@ void draw_gps2_hdop() {
     return;
   }
 
-  sprintf(tmp_str, "HDOP %0.1f", (double) osd_hdop2 / 100.0f);
+  sprintf(tmp_str, "HDOP %0.1f", (double) osdproc_osd_state.osd_hdop2 / 100.0f);
   write_string(tmp_str, eeprom_buffer.params.Gps2HDOP_posX,
                eeprom_buffer.params.Gps2HDOP_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.Gps2HDOP_align, 0,
@@ -677,7 +754,7 @@ void draw_gps2_latitude() {
     return;
   }
 
-  sprintf(tmp_str, "%0.5f", (double) osd_lat2 / DEGREE_MULTIPLIER);
+  sprintf(tmp_str, "%0.5f", (double) osdproc_osd_state.osd_lat2 / DEGREE_MULTIPLIER);
   write_string(tmp_str, eeprom_buffer.params.Gps2Lat_posX,
                eeprom_buffer.params.Gps2Lat_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.Gps2Lat_align, 0,
@@ -690,7 +767,7 @@ void draw_gps2_longitude() {
     return;
   }
 
-  sprintf(tmp_str, "%0.5f", (double) osd_lon2 / DEGREE_MULTIPLIER);
+  sprintf(tmp_str, "%0.5f", (double) osdproc_osd_state.osd_lon2 / DEGREE_MULTIPLIER);
   write_string(tmp_str, eeprom_buffer.params.Gps2Lon_posX,
                eeprom_buffer.params.Gps2Lon_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.Gps2Lon_align, 0,
@@ -703,7 +780,14 @@ void draw_total_trip() {
     return;
   }
 
-  float tmp = osd_total_trip_dist * convert_distance;
+  float tmp = 0.0f;
+  // Get total trip distance using the ad-hoc mutex & global structure  
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      tmp = adhoc_osd_state.osd_total_trip_dist * convert_distance; 
+      // Release the ad-hoc mutex
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  
   if (tmp < convert_distance_divider) {
     sprintf(tmp_str, "%d%s", (int) tmp, dist_unit_short);
   }
@@ -722,11 +806,14 @@ void draw_time() {
     return;
   }
 
-  uint32_t time_now = GetSystimeMS() - sys_start_time;
+  uint32_t time_now = GetSystimeMS() - get_sys_start_time();
 
   if (eeprom_buffer.params.Time_type == 1) {
-    time_now = heatbeat_start_time ? (GetSystimeMS() - heatbeat_start_time) : 0;
+    uint32_t heartbeat_start_time = get_heartbeat_start_time();
+    time_now = heartbeat_start_time ? (GetSystimeMS() - heartbeat_start_time) : 0;
   } else if (eeprom_buffer.params.Time_type == 2) {
+    uint32_t armed_start_time = get_armed_start_time();
+    uint32_t total_armed_time = get_total_armed_time();
     time_now = armed_start_time ? (GetSystimeMS() - armed_start_time + total_armed_time) : total_armed_time;
   }
 
@@ -777,26 +864,37 @@ float get_distance_between_locations_in_meters(float lat_from,
     return distance;
 }
 
-float get_distance_from_home_in_meters() {
-    // Distance to home is always 0.0 if home isn't set yet
-    if (osd_got_home == 0) {
+float get_distance_from_home_in_meters() {    
+    // Distance to home is always 0 if home isn't set yet
+    if (get_osd_got_home() == 0) {
         return 0.0f;
-    }    
-    
-    return get_distance_between_locations_in_meters(osd_home_lat, osd_home_lon, osd_lat, osd_lon);
+    }
+        
+    float osd_lat_current  = osdproc_osd_state.osd_lat;
+    float osd_lon_current  = osdproc_osd_state.osd_lon;
+    float osd_home_lat = get_osd_home_lat();
+    float osd_home_lon = get_osd_home_lon();
+      
+    return get_distance_between_locations_in_meters(osd_home_lat, osd_home_lon, osd_lat_current, osd_lon_current);
 }
 
 // Thanks again to:
 // http://www.movable-type.co.uk/scripts/latlong.html
-float get_bearing_to_home_in_degrees() {    
+float get_bearing_to_home_in_degrees() {   
+
     // Bearing to home is always 0 (north) if home isn't set yet
-    if (osd_got_home == 0) {
+    if (get_osd_got_home() == 0) {
         return 0.0f;
-    }    
-    
-    float phi_1 = Convert_Angle_To_Radians(osd_lat / DEGREE_MULTIPLIER);
+    }
+
+    float osd_lat_current  = osdproc_osd_state.osd_lat;
+    float osd_lon_current  = osdproc_osd_state.osd_lon; 
+    float osd_home_lat = get_osd_home_lat();
+    float osd_home_lon = get_osd_home_lon();    
+      
+    float phi_1 = Convert_Angle_To_Radians(osd_lat_current / DEGREE_MULTIPLIER);
     float phi_2 = Convert_Angle_To_Radians(osd_home_lat / DEGREE_MULTIPLIER);
-    float delta_lambda = Convert_Angle_To_Radians((osd_home_lon / DEGREE_MULTIPLIER) - (osd_lon / DEGREE_MULTIPLIER));
+    float delta_lambda = Convert_Angle_To_Radians((osd_home_lon / DEGREE_MULTIPLIER) - (osd_lon_current / DEGREE_MULTIPLIER));
 
     // see http://mathforum.org/library/drmath/view/55417.html
     float y = sin(delta_lambda) * cos(phi_2);
@@ -808,15 +906,15 @@ float get_bearing_to_home_in_degrees() {
 }
 
 void draw_distance_to_home() {
-    if (!enabledAndShownOnPanel(eeprom_buffer.params.CWH_home_dist_en,
+    if (!enabledAndShownOnPanel(eeprom_buffer.params.CWH_home_dist_en, 
                               eeprom_buffer.params.CWH_home_dist_panel)) {
       return;
     }
-
-    float tmp = osd_home_distance * convert_distance;
-   
+        
+    float tmp = get_osd_home_distance() * convert_distance;
+    
     // If home not set, give some indication that distance to home is currently meaningless
-    if (osd_got_home == 0) {
+    if (get_osd_got_home() == 0){
         sprintf(tmp_str, "H -%s", dist_unit_short);
     // Display short units (meters/feet)
     } else if (tmp < convert_distance_divider) {
@@ -824,19 +922,19 @@ void draw_distance_to_home() {
     // Display long units (kilometers/miles)
     } else {
         sprintf(tmp_str, "H %0.2f%s", (double)(tmp / convert_distance_divider), dist_unit_long);
-    }    
-  
-    write_string(tmp_str, eeprom_buffer.params.CWH_home_dist_posX, eeprom_buffer.params.CWH_home_dist_posY, 0, 0, TEXT_VA_TOP, eeprom_buffer.params.CWH_home_dist_align, 0, SIZE_TO_FONT[eeprom_buffer.params.CWH_home_dist_fontsize]);
+    }
+
+    write_string(tmp_str, eeprom_buffer.params.CWH_home_dist_posX, eeprom_buffer.params.CWH_home_dist_posY, 0, 0, TEXT_VA_TOP, eeprom_buffer.params.CWH_home_dist_align, 0, SIZE_TO_FONT[eeprom_buffer.params.CWH_home_dist_fontsize]);  
 }
 
 void draw_distance_to_waypoint() {
-  if (!enabledAndShownOnPanel(eeprom_buffer.params.CWH_wp_dist_en,
+  if (!enabledAndShownOnPanel(eeprom_buffer.params.CWH_wp_dist_en, 
                               eeprom_buffer.params.CWH_wp_dist_panel)) {
       return;
-  }
-
-    if (wp_number != 0) {
-         float tmp = wp_dist * convert_distance;
+  } 
+    
+    if (osdproc_osd_state.wp_number != 0) {
+         float tmp = osdproc_osd_state.wp_dist * convert_distance;
          if (tmp < convert_distance_divider) {
             sprintf(tmp_str, "WP %d%s", (int)tmp, dist_unit_short);
          }
@@ -849,29 +947,37 @@ void draw_distance_to_waypoint() {
 }
 
 // Set Home Position if needed.
-// (Might be able to move this to main task loop? -- SLG)
 void set_home_position_if_unset() {
-  if ((osd_got_home == 0) && (motor_armed) && (osd_fix_type > 1)) {
-    osd_home_lat = osd_lat;
-    osd_home_lon = osd_lon;
-    osd_alt_cnt = 0;
-    osd_got_home = 1;
+  if ((get_osd_got_home() == 0) && (osdproc_osd_state.motor_armed) && (osdproc_osd_state.osd_fix_type > 1)) {
+      
+    float osd_lat_current  = osdproc_osd_state.osd_lat;
+    float osd_lon_current  = osdproc_osd_state.osd_lon;
+    
+    set_osd_home_lat(osd_lat_current);
+    set_osd_home_lon(osd_lon_current);
+    get_osd_alt_cnt(0);
+    set_osd_got_home(1);
   }
 }
 
+// Set home altitude if needed
 void set_home_altitude_if_unset() {
-    if (osd_got_home == 1)
+    if (get_osd_got_home() == 1)
     {
+        float osd_alt_current = osdproc_osd_state.osd_alt;
+        uint8_t osd_alt_cnt_current = get_osd_alt_cnt();
+        float osd_alt_prev = get_osd_alt_prev();
+        
         // JRChange: osd_home_alt: check for stable osd_alt (must be stable for 75*40ms = 3s)
         // we can get the relative alt from mavlink directly.
-        if (osd_alt_cnt < 75) {
-          if (fabs(osd_alt_prev - osd_alt) > 0.5) {
-            osd_alt_cnt = 0;
-            osd_alt_prev = osd_alt;
+        if (osd_alt_cnt_current < 75) {
+          if (fabs(osd_alt_prev - osd_alt_current) > 0.5) {
+            set_osd_alt_cnt(0);
+            set_osd_alt_prev(osd_alt_current);
           } else {
-            osd_alt_cnt++;
-            if (osd_alt_cnt >= 75) {
-              osd_home_alt = osd_alt;           // take this stable osd_alt as osd_home_alt
+            set_osd_alt_cnt(osd_alt_cnt_current++);
+            if (osd_alt_cnt_current >= 75) {
+              set_osd_home_alt(osd_alt_current);           // take this stable osd_alt as osd_home_alt
             }
           }
         }
@@ -880,36 +986,48 @@ void set_home_altitude_if_unset() {
 
 // Set home distance and bearing, if we know where home is
 void set_home_distance_and_bearing() {
-  if (osd_got_home == 1) {
-    osd_home_distance = get_distance_from_home_in_meters();
-    osd_home_bearing = get_bearing_to_home_in_degrees();
+  if (get_osd_got_home() == 1) {
+    set_osd_home_distance(get_distance_from_home_in_meters());
+    set_osd_home_bearing(get_bearing_to_home_in_degrees());
   }
 }
 
 // direction - scale mode
 void draw_osd_linear_compass() {
-  if (!enabledAndShownOnPanel(eeprom_buffer.params.CWH_Tmode_en,
+  if (!enabledAndShownOnPanel(eeprom_buffer.params.CWH_Tmode_en, 
                               eeprom_buffer.params.CWH_Tmode_panel)) {
       return;
   }
-
-  draw_linear_compass(osd_heading, 0, 120, 180, GRAPHICS_X_MIDDLE, eeprom_buffer.params.CWH_Tmode_posY, 15, 30, 5, 8, 0);
+  
+  draw_linear_compass(osdproc_osd_state.osd_heading, 0, 120, 180, GRAPHICS_X_MIDDLE, eeprom_buffer.params.CWH_Tmode_posY, 15, 30, 5, 8, 0);
 }
+
+float get_new_updated_average_climb_rate() {
+    float average_climb = 0.0f;
+    
+    // Take the ad-hoc global mutex
+    if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+        adhoc_osd_state.osd_climb_ma[adhoc_osd_state.osd_climb_ma_index] = osdproc_osd_state.osd_climb;
+        adhoc_osd_state.osd_climb_ma_index = (adhoc_osd_state.osd_climb_ma_index + 1) % 10;
+        for (int i = 0; i < 10; i++) {
+            average_climb = average_climb + adhoc_osd_state.osd_climb_ma[i];
+        }
+        average_climb = roundf(10 * (average_climb / 10)) / 10.0f;
+
+        // Release the ad-hoc mutex
+        xSemaphoreGive(osd_state_adhoc_mutex);
+    }
+    return average_climb;
+}
+
 
 void draw_climb_rate() {
   if (!enabledAndShownOnPanel(eeprom_buffer.params.ClimbRate_en,
                               eeprom_buffer.params.ClimbRate_panel)) {
     return;
   }
-
-  float average_climb = 0.0f;
-  osd_climb_ma[osd_climb_ma_index] = osd_climb;
-  osd_climb_ma_index = (osd_climb_ma_index + 1) % 10;
-  for (int i = 0; i < 10; i++) {
-    average_climb = average_climb + osd_climb_ma[i];
-  }
-  average_climb = roundf(10 * (average_climb / 10)) / 10.0f;
-
+  
+  float average_climb = get_new_updated_average_climb_rate();
   int x = eeprom_buffer.params.ClimbRate_posX;
   int y = eeprom_buffer.params.ClimbRate_posY;
   sprintf(tmp_str, "%0.1f", fabs(average_climb));
@@ -938,23 +1056,23 @@ void draw_rssi() {
     return;
   }
 
-  int rssi = (int)osd_rssi;
+  int rssi = (int)osdproc_osd_state.osd_rssi;
 
   //Not from the MAVLINK, should take the RC channel PWM value.
   if (eeprom_buffer.params.RSSI_type != 0)
   {
-    if (eeprom_buffer.params.RSSI_type == 5) rssi = (int)osd_chan5_raw;
-    else if (eeprom_buffer.params.RSSI_type == 6) rssi = (int)osd_chan6_raw;
-    else if (eeprom_buffer.params.RSSI_type == 7) rssi = (int)osd_chan7_raw;
-    else if (eeprom_buffer.params.RSSI_type == 8) rssi = (int)osd_chan8_raw;
-    else if (eeprom_buffer.params.RSSI_type == 9) rssi = (int)osd_chan9_raw;
-    else if (eeprom_buffer.params.RSSI_type == 10) rssi = (int)osd_chan10_raw;
-    else if (eeprom_buffer.params.RSSI_type == 11) rssi = (int)osd_chan11_raw;
-    else if (eeprom_buffer.params.RSSI_type == 12) rssi = (int)osd_chan12_raw;
-    else if (eeprom_buffer.params.RSSI_type == 13) rssi = (int)osd_chan13_raw;
-    else if (eeprom_buffer.params.RSSI_type == 14) rssi = (int)osd_chan14_raw;
-    else if (eeprom_buffer.params.RSSI_type == 15) rssi = (int)osd_chan15_raw;
-    else if (eeprom_buffer.params.RSSI_type == 16) rssi = (int)osd_chan16_raw;
+    if (eeprom_buffer.params.RSSI_type == 5) rssi = (int)osdproc_osd_state.osd_chan5_raw;
+    else if (eeprom_buffer.params.RSSI_type == 6) rssi = (int)osdproc_osd_state.osd_chan6_raw;
+    else if (eeprom_buffer.params.RSSI_type == 7) rssi = (int)osdproc_osd_state.osd_chan7_raw;
+    else if (eeprom_buffer.params.RSSI_type == 8) rssi = (int)osdproc_osd_state.osd_chan8_raw;
+    else if (eeprom_buffer.params.RSSI_type == 9) rssi = (int)osdproc_osd_state.osd_chan9_raw;
+    else if (eeprom_buffer.params.RSSI_type == 10) rssi = (int)osdproc_osd_state.osd_chan10_raw;
+    else if (eeprom_buffer.params.RSSI_type == 11) rssi = (int)osdproc_osd_state.osd_chan11_raw;
+    else if (eeprom_buffer.params.RSSI_type == 12) rssi = (int)osdproc_osd_state.osd_chan12_raw;
+    else if (eeprom_buffer.params.RSSI_type == 13) rssi = (int)osdproc_osd_state.osd_chan13_raw;
+    else if (eeprom_buffer.params.RSSI_type == 14) rssi = (int)osdproc_osd_state.osd_chan14_raw;
+    else if (eeprom_buffer.params.RSSI_type == 15) rssi = (int)osdproc_osd_state.osd_chan15_raw;
+    else if (eeprom_buffer.params.RSSI_type == 16) rssi = (int)osdproc_osd_state.osd_chan16_raw;
   }
 
   //0:percentage 1:raw
@@ -996,18 +1114,18 @@ void draw_link_quality() {
   int min = eeprom_buffer.params.LinkQuality_min;
   int max = eeprom_buffer.params.LinkQuality_max;
 
-  if (eeprom_buffer.params.LinkQuality_chan == 5) linkquality = (int)osd_chan5_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 6) linkquality = (int)osd_chan6_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 7) linkquality = (int)osd_chan7_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 8) linkquality = (int)osd_chan8_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 9) linkquality = (int)osd_chan9_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 10) linkquality = (int)osd_chan10_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 11) linkquality = (int)osd_chan11_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 12) linkquality = (int)osd_chan12_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 13) linkquality = (int)osd_chan13_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 14) linkquality = (int)osd_chan14_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 15) linkquality = (int)osd_chan15_raw;
-  else if (eeprom_buffer.params.LinkQuality_chan == 16) linkquality = (int)osd_chan16_raw;
+  if (eeprom_buffer.params.LinkQuality_chan == 5) linkquality = (int)osdproc_osd_state.osd_chan5_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 6) linkquality = (int)osdproc_osd_state.osd_chan6_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 7) linkquality = (int)osdproc_osd_state.osd_chan7_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 8) linkquality = (int)osdproc_osd_state.osd_chan8_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 9) linkquality = (int)osdproc_osd_state.osd_chan9_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 10) linkquality = (int)osdproc_osd_state.osd_chan10_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 11) linkquality = (int)osdproc_osd_state.osd_chan11_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 12) linkquality = (int)osdproc_osd_state.osd_chan12_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 13) linkquality = (int)osdproc_osd_state.osd_chan13_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 14) linkquality = (int)osdproc_osd_state.osd_chan14_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 15) linkquality = (int)osdproc_osd_state.osd_chan15_raw;
+  else if (eeprom_buffer.params.LinkQuality_chan == 16) linkquality = (int)osdproc_osd_state.osd_chan16_raw;
 
   // 0: percent, 1: raw
   if (eeprom_buffer.params.LinkQuality_type == 0) {
@@ -1042,8 +1160,8 @@ void draw_efficiency() {
     return;
   }
 
-  float wattage = osd_vbat_A * osd_curr_A * 0.01;
-  float speed = osd_groundspeed * convert_speed;
+  float wattage = osdproc_osd_state.osd_vbat_A * osdproc_osd_state.osd_curr_A * 0.01;
+  float speed = osdproc_osd_state.osd_groundspeed * convert_speed;
   float efficiency = 0;
   if (speed != 0) {
     efficiency = wattage / speed;
@@ -1061,7 +1179,7 @@ void draw_watts() {
     return;
   }
 
-  sprintf(tmp_str, "%0.1fW", osd_vbat_A * osd_curr_A * 0.01);
+  sprintf(tmp_str, "%0.1fW", osdproc_osd_state.osd_vbat_A * osdproc_osd_state.osd_curr_A * 0.01);
 
   write_string(tmp_str, eeprom_buffer.params.Watts_posX, eeprom_buffer.params.Watts_posY,
                0, 0, TEXT_VA_TOP, eeprom_buffer.params.Watts_align, 0,
@@ -1069,6 +1187,7 @@ void draw_watts() {
 }
 
 void draw_panel_changed() {
+  uint8_t current_panel = get_current_panel();
   if (last_panel != current_panel) {
     last_panel = current_panel;
     new_panel_start_time = GetSystimeMS();
@@ -1106,22 +1225,22 @@ void draw_version_splash() {
     version_splash_start_time = GetSystimeMS();
   }
         
-  // Show the splash screen  
+  // Show the splash screen
   int font_number_line_one = 0;
   struct FontEntry font_info_line_one;
-  fetch_font_info(0, font_number_line_one, &font_info_line_one, NULL);      
+  fetch_font_info(0, font_number_line_one, &font_info_line_one, NULL);
   char version_str_line_one[15];
   struct FontDimensions line_one_font_dim;
   memset (version_str_line_one, ' ', 15);    
   sprintf(version_str_line_one, "PLAYUAV V%s", PLAYUAV_VERSION_NUMBER);
   calc_text_dimensions(version_str_line_one, font_info_line_one, 1, 0, &line_one_font_dim);
   
-  int font_number_line_two = 1;  
-  struct FontEntry font_info_line_two;  
-  fetch_font_info(0, font_number_line_two, &font_info_line_two, NULL);      
+  int font_number_line_two = 1;
+  struct FontEntry font_info_line_two;
+  fetch_font_info(0, font_number_line_two, &font_info_line_two, NULL);
   char version_str_line_two[15];
-  struct FontDimensions line_two_font_dim;    
-  memset (version_str_line_two, ' ', 15);    
+  struct FontDimensions line_two_font_dim;
+  memset (version_str_line_two, ' ', 15);
   sprintf(version_str_line_two, "%s", PLAYUAV_VERSION_DESCRIPTION);
   calc_text_dimensions(version_str_line_two, font_info_line_two, 1, 0, &line_two_font_dim);    
   
@@ -1470,15 +1589,19 @@ void draw_head_wp_home() {
   VECTOR2D_INITXYZ(&(suav.vlist_local[1]), -3, 7);
   VECTOR2D_INITXYZ(&(suav.vlist_local[2]), 3, 7);
   Reset_Polygon2D(&suav);
-  Rotate_Polygon2D(&suav, osd_heading);
+  Rotate_Polygon2D(&suav, osdproc_osd_state.osd_heading);
   write_line_outlined(suav.vlist_trans[0].x + suav.x0, suav.vlist_trans[0].y + suav.y0,
                       suav.vlist_trans[1].x + suav.x0, suav.vlist_trans[1].y + suav.y0, 2, 2, 0, 1);
   write_line_outlined(suav.vlist_trans[0].x + suav.x0, suav.vlist_trans[0].y + suav.y0,
                       suav.vlist_trans[2].x + suav.x0, suav.vlist_trans[2].y + suav.y0, 2, 2, 0, 1);
-
+   
+  uint32_t osd_home_bearing = get_osd_home_bearing();
+  uint8_t home_is_set = get_osd_got_home();
+  long home_distance = get_osd_home_distance();
+  
   // Draw home 
   // Home only shown when home is set, and the distance to home is greater than 1 meter
-  if ((osd_got_home == 1) && ((int32_t)osd_home_distance > 1))    
+  if (((int32_t)home_distance > 1) && (home_is_set == 1))
   {
     float homeCX = posX + (eeprom_buffer.params.CWH_Nmode_home_radius) * Fast_Sin(osd_home_bearing);
     float homeCY = posY - (eeprom_buffer.params.CWH_Nmode_home_radius) * Fast_Cos(osd_home_bearing);
@@ -1486,13 +1609,13 @@ void draw_head_wp_home() {
   }
 
   //draw waypoint
-  if ((wp_number != 0) && (wp_dist > 1))
+  if ((osdproc_osd_state.wp_number != 0) && (osdproc_osd_state.wp_dist > 1))
   {
     //format bearing
-    wp_target_bearing = (wp_target_bearing + 360) % 360;
-    float wpCX = posX + (eeprom_buffer.params.CWH_Nmode_wp_radius) * Fast_Sin(wp_target_bearing);
-    float wpCY = posY - (eeprom_buffer.params.CWH_Nmode_wp_radius) * Fast_Cos(wp_target_bearing);
-    sprintf(tmp_str, "%d", (int)wp_number);
+    osdproc_osd_state.wp_target_bearing = (osdproc_osd_state.wp_target_bearing + 360) % 360;
+    float wpCX = posX + (eeprom_buffer.params.CWH_Nmode_wp_radius) * Fast_Sin(osdproc_osd_state.wp_target_bearing);
+    float wpCY = posY - (eeprom_buffer.params.CWH_Nmode_wp_radius) * Fast_Cos(osdproc_osd_state.wp_target_bearing);
+    sprintf(tmp_str, "%d", (int)osdproc_osd_state.wp_number);
     write_string(tmp_str, wpCX, wpCY, 0, 0, TEXT_VA_MIDDLE, TEXT_HA_CENTER, 0, SIZE_TO_FONT[0]);
   }
 }
@@ -1521,7 +1644,7 @@ void draw_wind(void) {
   VECTOR2D_INITXYZ(&(obj2D.vlist_local[3]), 0, 8);
   VECTOR2D_INITXYZ(&(obj2D.vlist_local[4]), 0, -2);
   Reset_Polygon2D(&obj2D);
-  Rotate_Polygon2D(&obj2D, osd_windDir);
+  Rotate_Polygon2D(&obj2D, osdproc_osd_state.osd_windDir);
   write_triangle_wire(obj2D.vlist_trans[0].x + obj2D.x0, obj2D.vlist_trans[0].y + obj2D.y0,
                       obj2D.vlist_trans[1].x + obj2D.x0, obj2D.vlist_trans[1].y + obj2D.y0,
                       obj2D.vlist_trans[2].x + obj2D.x0, obj2D.vlist_trans[2].y + obj2D.y0);
@@ -1529,7 +1652,7 @@ void draw_wind(void) {
                       obj2D.vlist_trans[4].x + obj2D.x0, obj2D.vlist_trans[4].y + obj2D.y0, 2, 2, 0, 1);
 
   //draw wind speed
-  float tmp = osd_windSpeed * convert_speed;
+  float tmp = osdproc_osd_state.osd_windSpeed * convert_speed;
   sprintf(tmp_str, "%.2f%s", tmp, spd_unit);
   write_string(tmp_str, posX + 15, posY, 0, 0, TEXT_VA_MIDDLE, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);
 }
@@ -1576,21 +1699,21 @@ void draw_warning(void) {
   uint8_t warning[] = { 0, 0, 0, 0, 0, 0, 0 };
 
   //no GPS fix!
-  if (eeprom_buffer.params.Alarm_GPS_status_en == 1 && (osd_fix_type < GPS_OK_FIX_3D)) {
+  if (eeprom_buffer.params.Alarm_GPS_status_en == 1 && (osdproc_osd_state.osd_fix_type < GPS_OK_FIX_3D)) {
     //debug_warnings_two();
     haswarn = true;
     warning[0] = 1;
   }
 
   //low batt
-  if (eeprom_buffer.params.Alarm_low_batt_en == 1 && (osd_battery_remaining_A < eeprom_buffer.params.Alarm_low_batt)) {
+  if (eeprom_buffer.params.Alarm_low_batt_en == 1 && (osdproc_osd_state.osd_battery_remaining_A < eeprom_buffer.params.Alarm_low_batt)) {
     haswarn = true;
     warning[1] = 1;
   }
 
-  float spd_comparison = osd_groundspeed;
+  float spd_comparison = osdproc_osd_state.osd_groundspeed;
   if (eeprom_buffer.params.Spd_Scale_type == 1) {
-    spd_comparison = osd_airspeed;
+    spd_comparison = osdproc_osd_state.osd_airspeed;
   }
   spd_comparison *= convert_speed;
   //under speed
@@ -1605,7 +1728,11 @@ void draw_warning(void) {
     warning[3] = 1;
   }
 
-  float alt_comparison = osd_rel_alt;
+  // float osd_alt = 0.0f;
+  // get_osd_alt(&osd_alt);
+  float osd_alt = osdproc_osd_state.osd_alt;  
+    
+  float alt_comparison = osdproc_osd_state.osd_rel_alt;
   if (eeprom_buffer.params.Alt_Scale_type == 0) {
     alt_comparison = osd_alt;
   }
@@ -1622,7 +1749,7 @@ void draw_warning(void) {
   }
 
   // no home yet
-  if (osd_got_home == 0) {
+  if (get_osd_got_home() == 0) {
     haswarn = true;
     warning[6] = 1;
   }
@@ -1639,7 +1766,7 @@ void draw_warning(void) {
     if (last_warn_type == 0) {
       last_warn_type++;
       if (warning[0] == 1) {
-          warn_str = "NO GPS FIX";          
+          warn_str = "NO GPS FIX";
           return;
       }
     }
@@ -1647,50 +1774,50 @@ void draw_warning(void) {
     if (last_warn_type == 1) {
       last_warn_type++;
       if (warning[1] == 1) {
-          warn_str = "LOW BATTERY";          
+          warn_str = "LOW BATTERY";
           return;
       }
-    }    
+    }
     
     if (last_warn_type == 2) {
       last_warn_type++;
       if (warning[2] == 1) {
-          warn_str = "SPEED LOW";          
+          warn_str = "SPEED LOW";
           return;
       }
-    }    
+    }
     
     if (last_warn_type == 3) {
       last_warn_type++;
       if (warning[3] == 1) {
-          warn_str = "OVER SPEED";          
+          warn_str = "OVER SPEED";
           return;
       }
-    }    
+    }
     
     if (last_warn_type == 4) {
       last_warn_type++;
       if (warning[4] == 1) {
-          warn_str = "LOW ALT";          
+          warn_str = "LOW ALT";
           return;
       }
-    }    
+    }
     
     if (last_warn_type == 5) {
       last_warn_type++;
       if (warning[5] == 1) {
-          warn_str = "HIGH ALT";          
+          warn_str = "HIGH ALT";
           return;
       }
-    }    
+    }
     
     if (last_warn_type == 6) {
       last_warn_type++;
       if (warning[6] == 1) {
-          warn_str = "NO HOME POSITION SET";          
+          warn_str = "NO HOME POSITION SET";
           return;
       }
-    }    
+    }
 
     // If we didn't match, there's a coding
     // error of some kind. Warn the user/developer.
@@ -1718,16 +1845,16 @@ void debug_wps(void) {
 
 //    float uav_lat = osd_lat / DEGREE_MULTIPLIER;
 //    float uav_lon = osd_lon / DEGREE_MULTIPLIER;
-  float home_lat = osd_home_lat / DEGREE_MULTIPLIER;
-  float home_lon = osd_home_lon / DEGREE_MULTIPLIER;
+  float home_lat = get_osd_home_lat() / DEGREE_MULTIPLIER;
+  float home_lon = get_osd_home_lon() / DEGREE_MULTIPLIER;
 
 //    if(osd_fix_type > 1){
 //        sprintf(tmp_str, "UAV X:%0.12f Y:%0.12f",(double)uav_lat,(double)uav_lon);
 //        write_string(tmp_str, 10, a, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);
 //        a += 15;
 //    }
-
-  if (osd_got_home == 1) {
+  
+  if (get_osd_got_home() == 1) {
 //        sprintf(tmp_str, "home X:%0.12f Y:%0.12f",(double)home_lat,(double)home_lon);
 //        write_string(tmp_str, 10, a, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[0]);
 //        a += 15;
@@ -1778,9 +1905,12 @@ void draw_flight_mode() {
   }
 
   char* mode_str = "UNKNOWN";
-  switch (autopilot) {
+  switch (osdproc_osd_state.autopilot) {
   case 3:       //ardupilotmega
   {
+    uint32_t custom_mode = osdproc_osd_state.custom_mode;
+    uint8_t mav_type = get_mav_type();
+    
     if (mav_type != 1) {
       if (custom_mode == 0)       mode_str = "STAB";              //manual airframe angle with manual throttle
       else if (custom_mode == 1)  mode_str = "ACRO";              //manual body-frame angular rate with manual throttle
@@ -1821,7 +1951,7 @@ void draw_flight_mode() {
   case 12:       //PX4
   {
     union px4_custom_mode custom_mode_px4;
-    custom_mode_px4.data = custom_mode;
+    custom_mode_px4.data = osdproc_osd_state.custom_mode;
 
     if (custom_mode_px4.main_mode == 1) mode_str = "MANUAL";
     else if (custom_mode_px4.main_mode == 2) mode_str = "ALTCTL";
@@ -1862,7 +1992,7 @@ void draw_arm_state() {
     return;
   }
 
-  tmp_str1 = motor_armed ? "ARMED" : "DISARMED";
+  tmp_str1 = osdproc_osd_state.motor_armed ? "ARMED" : "DISARMED";
   write_string(tmp_str1, eeprom_buffer.params.Arm_posX,
                eeprom_buffer.params.Arm_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.Arm_align, 0,
@@ -1875,7 +2005,7 @@ void draw_battery_voltage() {
     return;
   }
 
-  sprintf(tmp_str, "%0.1fV", (double) osd_vbat_A);
+  sprintf(tmp_str, "%0.1fV", (double) osdproc_osd_state.osd_vbat_A);
   write_string(tmp_str, eeprom_buffer.params.BattVolt_posX,
                eeprom_buffer.params.BattVolt_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.BattVolt_align, 0,
@@ -1888,7 +2018,7 @@ void draw_battery_current() {
     return;
   }
 
-  sprintf(tmp_str, "%0.1fA", (double) (osd_curr_A * 0.01));
+  sprintf(tmp_str, "%0.1fA", (double) (osdproc_osd_state.osd_curr_A * 0.01));
   write_string(tmp_str, eeprom_buffer.params.BattCurrent_posX,
                eeprom_buffer.params.BattCurrent_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.BattCurrent_align, 0,
@@ -1901,7 +2031,7 @@ void draw_battery_remaining() {
     return;
   }
 
-  sprintf(tmp_str, "%d%%", osd_battery_remaining_A);
+  sprintf(tmp_str, "%d%%", osdproc_osd_state.osd_battery_remaining_A);
   write_string(tmp_str, eeprom_buffer.params.BattRemaining_posX,
                eeprom_buffer.params.BattRemaining_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.BattRemaining_align, 0,
@@ -1914,7 +2044,7 @@ void draw_battery_consumed() {
     return;
   }
 
-  sprintf(tmp_str, "%dmah", (int)osd_curr_consumed_mah);
+  sprintf(tmp_str, "%dmah", (int)get_current_consumed_mah());
   write_string(tmp_str, eeprom_buffer.params.BattConsumed_posX,
                eeprom_buffer.params.BattConsumed_posY, 0, 0, TEXT_VA_TOP,
                eeprom_buffer.params.BattConsumed_align, 0,
@@ -1927,7 +2057,9 @@ void draw_altitude_scale() {
     return;
   }
 
-  float alt_shown = osd_rel_alt;
+  float osd_alt = osdproc_osd_state.osd_alt;      
+  float alt_shown = osdproc_osd_state.osd_rel_alt;
+  
   uint16_t posX = eeprom_buffer.params.Alt_Scale_posX;
   sprintf(tmp_str, "Alt");
   if (eeprom_buffer.params.Alt_Scale_type == 0) {
@@ -1961,7 +2093,9 @@ void draw_absolute_altitude() {
     return;
   }
 
+  float osd_alt = osdproc_osd_state.osd_alt;     
   float tmp = osd_alt * convert_distance;
+
   if (tmp < convert_distance_divider) {
     sprintf(tmp_str, "AA %d%s", (int) tmp, dist_unit_short);
   }
@@ -1981,7 +2115,7 @@ void draw_relative_altitude() {
     return;
   }
 
-  float tmp = osd_rel_alt * convert_distance;
+  float tmp = osdproc_osd_state.osd_rel_alt * convert_distance;
   if (tmp < convert_distance_divider) {
     sprintf(tmp_str, "A %d%s", (int) tmp, dist_unit_short);
   }
@@ -2001,10 +2135,10 @@ void draw_speed_scale() {
     return;
   }
 
-  float spd_shown = osd_groundspeed;
+  float spd_shown = osdproc_osd_state.osd_groundspeed;
   sprintf(tmp_str, "GS");
   if (eeprom_buffer.params.Spd_Scale_type == 1) {
-    spd_shown = osd_airspeed;
+    spd_shown = osdproc_osd_state.osd_airspeed;
     sprintf(tmp_str, "AS");
   }
   draw_vertical_scale(spd_shown * convert_speed, 60,
@@ -2030,7 +2164,7 @@ void draw_ground_speed() {
     return;
   }
 
-  float tmp = osd_groundspeed * convert_speed;
+  float tmp = osdproc_osd_state.osd_groundspeed * convert_speed;
   sprintf(tmp_str, "GS %d%s", (int) tmp, spd_unit);
   write_string(tmp_str, eeprom_buffer.params.TSPD_posX,
                eeprom_buffer.params.TSPD_posY, 0, 0, TEXT_VA_TOP,
@@ -2044,7 +2178,7 @@ void draw_air_speed() {
     return;
   }
 
-  float tmp = osd_airspeed * convert_speed;
+  float tmp = osdproc_osd_state.osd_airspeed * convert_speed;
   sprintf(tmp_str, "AS %d%s", (int) tmp, spd_unit);
   write_string(tmp_str, eeprom_buffer.params.Air_Speed_posX,
                eeprom_buffer.params.Air_Speed_posY, 0, 0, TEXT_VA_TOP,
@@ -2052,21 +2186,56 @@ void draw_air_speed() {
                SIZE_TO_FONT[eeprom_buffer.params.Air_Speed_fontsize]);
 }
 
+/*
+void waypoint_debugging_for_draw_map() {
+    int debug_x = 30;
+    int debug_y = 30;
+  
+   // Got all waypoints
+   // ------------------------
+    sprintf(tmp_str, "got_all_WPs: %d", osdproc_osd_state.got_all_wps);
+    write_string(tmp_str, debug_x , debug_y, 0, 0, eeprom_buffer.params.Map_V_align, eeprom_buffer.params.Map_H_align, 0, SIZE_TO_FONT[eeprom_buffer.params.Map_fontsize]);
+  
+    // Waypoint count debug
+    // ---------------------------
+    sprintf(tmp_str, "WP Count: %d", osdproc_osd_state.wp_counts);
+    write_string(tmp_str, debug_x , debug_y + 15 , 0, 0, eeprom_buffer.params.Map_V_align, eeprom_buffer.params.Map_H_align, 0, SIZE_TO_FONT[eeprom_buffer.params.Map_fontsize]);
+    
+    // Dump whole waypoints array
+    // -------------------------------------------------------------
+    // DELIBERATELY walking off end for the moment!!!! Should probably be i < osdproc_osd_state.wp_counts!!!
+    for (int i = 0; i <= osdproc_osd_state.wp_counts; i++) {
+        sprintf(tmp_str, "wp_counts[%d] => LAT(X): %d LON(Y): %d ALT(Z): %d", i, osdproc_osd_state.wp_list[1].x, osdproc_osd_state.wp_list[1].y, osdproc_osd_state.wp_list[1].z);
+        write_string(tmp_str, debug_x , debug_y + 30 + (i * 15) , 0, 0, eeprom_buffer.params.Map_V_align, eeprom_buffer.params.Map_H_align, 0, SIZE_TO_FONT[eeprom_buffer.params.Map_fontsize]);   
+    }        
+}
+*/
+
+// Port to mutex-land of original draw_map code
 void draw_map(void) {
   if (!enabledAndShownOnPanel(eeprom_buffer.params.Map_en,
                               eeprom_buffer.params.Map_panel)) {
     return;
   }
 
-  if (got_all_wps == 0)
-    return;
+  // HACK - Do not ship this!
+  //waypoint_debugging_for_draw_map();    
+  
+  if (osdproc_osd_state.got_all_wps == 0) {
+    return;  
+  }    
 
+  uint8_t osd_got_home = get_osd_got_home();  
+  
   char tmp_str[50] = { 0 };
 
-  float uav_lat = osd_lat / DEGREE_MULTIPLIER;
-  float uav_lon = osd_lon / DEGREE_MULTIPLIER;
-  float home_lat = osd_home_lat / DEGREE_MULTIPLIER;
-  float home_lon = osd_home_lon / DEGREE_MULTIPLIER;
+  float osd_lat_current = osdproc_osd_state.osd_lat;
+  float osd_lon_current = osdproc_osd_state.osd_lon; 
+  
+  float uav_lat = osd_lat_current / DEGREE_MULTIPLIER;
+  float uav_lon = osd_lon_current / DEGREE_MULTIPLIER;
+  float home_lat = get_osd_home_lat() / DEGREE_MULTIPLIER;
+  float home_lon = get_osd_home_lon() / DEGREE_MULTIPLIER;
 
   float uav_x = 0.0f;
   float uav_y = 0.0f;
@@ -2077,12 +2246,11 @@ void draw_map(void) {
   rect.z = -999.0f;
   rect.w = 999.0f;
 
-  for (int i = 1; i < wp_counts; i++)
-  {
-    gen_overlay_rect(wp_list[i].x, wp_list[i].y, &rect);
+  for (int i = 1; i < osdproc_osd_state.wp_counts; i++) {
+    gen_overlay_rect(osdproc_osd_state.wp_list[i].x, osdproc_osd_state.wp_list[i].y, &rect);
   }
 
-  if (osd_fix_type > 1) {
+  if (osdproc_osd_state.osd_fix_type > 1) {
     gen_overlay_rect(uav_lat, uav_lon, &rect);
   }
 
@@ -2103,7 +2271,7 @@ void draw_map(void) {
 
   float dstlon, dstlat, scaleLongDown;
 
-  VERTEX2DF wps_screen_point[wp_counts];
+  VERTEX2DF wps_screen_point[osdproc_osd_state.wp_counts];
   scaleLongDown = Fast_Cos(fabs(rect.y));
   dstlon = fabs(rect.x - rect.z) * 111319.5f * scaleLongDown;
   dstlat = fabs(rect.y - rect.w) * 111319.5f;
@@ -2112,14 +2280,13 @@ void draw_map(void) {
   VERTEX2DF tmp_point;
   
   // Translate to screen coordinates for waypoints (if any)
-  for (int i = 1; i < wp_counts; i++)
-  {
-    wps_screen_point[i] = gps_to_screen_pixel(wp_list[i].x, wp_list[i].y, cent_lat, cent_lon,
+  for (int i = 1; i < osdproc_osd_state.wp_counts; i++) {
+    wps_screen_point[i] = gps_to_screen_pixel(osdproc_osd_state.wp_list[i].x, osdproc_osd_state.wp_list[i].y, cent_lat, cent_lon,
                                               rect_diagonal_half, cent_x, cent_y, radius);
   }
 
   // Translate to screen coordinates for UAV (if GPS location known)
-  if (osd_fix_type > 1) {
+  if (osdproc_osd_state.osd_fix_type > 1) {
     tmp_point = gps_to_screen_pixel(uav_lat, uav_lon, cent_lat, cent_lon,
                                     rect_diagonal_half, cent_x, cent_y, radius);
     uav_x = tmp_point.x;
@@ -2134,20 +2301,18 @@ void draw_map(void) {
   }
 
   // Draw lines between all waypoints (if any)
-  for (int i = 1; i < wp_counts - 1; i++)
-  {
+  for (int i = 1; i < osdproc_osd_state.wp_counts - 1; i++) {
     write_line_outlined(wps_screen_point[i].x, wps_screen_point[i].y, wps_screen_point[i + 1].x, wps_screen_point[i + 1].y, 2, 2, 0, 1);
   }
 
   // If home is set, and we have at least one waypoint, draw line between home and first waypoint
-  if (osd_got_home == 1 && wp_counts > 1) {
+  if (osd_got_home == 1 && osdproc_osd_state.wp_counts > 1) {
     write_line_outlined(wps_screen_point[0].x, wps_screen_point[0].y, wps_screen_point[1].x, wps_screen_point[1].y, 2, 2, 0, 1);
   }
 
   // Draw waypoint numbers (if any)
-  for (int i = 1; i < wp_counts; i++)
-  {
-    sprintf(tmp_str, "%d", wp_list[i].seq);
+  for (int i = 1; i < osdproc_osd_state.wp_counts; i++) {
+    sprintf(tmp_str, "%d", osdproc_osd_state.wp_list[i].seq);
     write_string(tmp_str, wps_screen_point[i].x, wps_screen_point[i].y, 0, 0, eeprom_buffer.params.Map_V_align, eeprom_buffer.params.Map_H_align, 0, SIZE_TO_FONT[eeprom_buffer.params.Map_fontsize]);
   }
 
@@ -2155,9 +2320,9 @@ void draw_map(void) {
   if (osd_got_home == 1) {
     write_string("H", wps_screen_point[0].x, wps_screen_point[0].y, 0, 0, eeprom_buffer.params.Map_V_align, eeprom_buffer.params.Map_H_align, 0, SIZE_TO_FONT[eeprom_buffer.params.Map_fontsize]);
   }
-
+  
   // Draw UAV (if GPS location known)
-  if (osd_fix_type > 1) {
+  if (osdproc_osd_state.osd_fix_type > 1) {
     //draw heading
     POLYGON2D suav;
     suav.state       = 1;
@@ -2168,7 +2333,7 @@ void draw_map(void) {
     VECTOR2D_INITXYZ(&(suav.vlist_local[1]), -5, 8);
     VECTOR2D_INITXYZ(&(suav.vlist_local[2]), 5, 8);
     Reset_Polygon2D(&suav);
-    Rotate_Polygon2D(&suav, osd_heading);
+    Rotate_Polygon2D(&suav, osdproc_osd_state.osd_heading);
     write_line_outlined(suav.vlist_trans[0].x + suav.x0, suav.vlist_trans[0].y + suav.y0,
                         suav.vlist_trans[1].x + suav.x0, suav.vlist_trans[1].y + suav.y0, 2, 2, 0, 1);
     write_line_outlined(suav.vlist_trans[0].x + suav.x0, suav.vlist_trans[0].y + suav.y0,
@@ -2176,6 +2341,7 @@ void draw_map(void) {
   }
 }
 
+/*
 void DJI_test(void) {
   char tmp_str[100] = { 0 };
 
@@ -2228,3 +2394,4 @@ void DJI_test(void) {
 
   draw_linear_compass(osd_heading, osd_home_bearing, 120, 180, GRAPHICS_X_MIDDLE, GRAPHICS_Y_MIDDLE + 80, 15, 30, 5, 8, 0);
 }
+*/

--- a/src/osdvar.c
+++ b/src/osdvar.c
@@ -93,9 +93,9 @@ void variable_mutexes_init() {
 
 // Copy an osd_state object in a thread-safe manner
 // May not succeed if the lock is not gained in tick_delay ticks
-void copy_osd_state_thread_safe(osd_state * p_osd_state_source, 
-                                osd_state * p_osd_state_target,
-                                TickType_t tick_delay) {    
+void copy_osd_state(osd_state * p_osd_state_source, 
+                    osd_state * p_osd_state_target,
+                    TickType_t tick_delay) {    
     if (xSemaphoreTake(osd_state_airlock_mutex, tick_delay) == pdTRUE ) {
         // Note that we deliberately DO NOT call clear_osd_state_struct() on the target -
         // this function can be used to copy TO the airlock, and there are values that

--- a/src/osdvar.c
+++ b/src/osdvar.c
@@ -20,122 +20,550 @@
 #include "osdvar.h"
 
 /////////////////////////////////////////////////////////////////////////
-uint8_t mavbeat = 0;
-uint32_t lastMAVBeat = 0;
-uint32_t lastWritePanel = 0;
-uint8_t waitingMAVBeats = 1;
-uint8_t mav_type;
-uint8_t mav_system;
-uint8_t mav_component;
-uint8_t enable_mav_request = 0;
-uint32_t sys_start_time = 0;
-uint32_t heatbeat_start_time = 0;
-uint32_t armed_start_time = 0;
-uint32_t total_armed_time = 0;
+
+// This is the OSD state that is unowned by any particular thread, and flows from
+// Mavlink/UAVTalk to the OSD thread. This is called the "airlock".
+osd_state airlock_osd_state = {};
+
+// This is other global OSD state that doesn't flow from a serial protocol to OSD,
+// but follows other patterns.
+other_osd_state adhoc_osd_state = {};
+
+// Clears out entire struct
+void clear_osd_state_struct(osd_state * pOsd_state) {        
+    // Set all bytes to 0
+    memset(pOsd_state, 0, sizeof(osd_state));
+    // Set legal defaults
+    
+}
+
+// Clears out entire struct
+void clear_other_ost_state_struct(other_osd_state * pOther_osd_state) {
+    // Set all bytes to 0
+    memset(pOther_osd_state, 0, sizeof(other_osd_state));
+    // Default current panel to 1
+    pOther_osd_state->current_panel = 1;
+}
 
 /////////////////////////////////////////////////////////////////////////
-float osd_vbat_A = 0.0f;                 // Battery A voltage in milivolt
-int16_t osd_curr_A = 0;                 // Battery A current
-int8_t osd_battery_remaining_A = 0;    // 0 to 100 <=> 0 to 1000
-float osd_curr_consumed_mah = 0;
+// Mutexes to protect safe access to variables shared 
+// between concurrent tasks.
+/////////////////////////////////////////////////////////////////////////
 
-float osd_pitch = 0.0f;                  // pitch from DCM
-float osd_roll = 0.0f;                   // roll from DCM
-float osd_yaw = 0.0f;                    // relative heading form DCM
-float osd_heading = 0.0f;                // ground course heading from GPS
+// This mutex controls access to the Mavlink OSD State
+extern xSemaphoreHandle osd_state_mavlink_mutex;
 
-float osd_lat = 0.0f;                    // latidude
-float osd_lon = 0.0f;                    // longitude
-uint8_t osd_satellites_visible = 0;     // number of satelites
-uint8_t osd_fix_type = 0;               // GPS lock 0-1=no fix, 2=2D, 3=3D
-double osd_hdop = 0.0f;
+// This mutex controls access to the airlock OSD State
+xSemaphoreHandle osd_state_airlock_mutex;
 
-float osd_lat2 = 0.0f;                    // latidude
-float osd_lon2 = 0.0f;                    // longitude
-uint8_t osd_satellites_visible2 = 0;     // number of satelites
-uint8_t osd_fix_type2 = 0;               // GPS lock 0-1=no fix, 2=2D, 3=3D
-double osd_hdop2 = 0.0f;
+// This mutex controls access to the OSDProc OSD State
+extern xSemaphoreHandle osd_state_osdproc_mutex;
 
-float osd_airspeed = -1.0f;              // airspeed
-float osd_groundspeed = 0.0f;            // ground speed
-float osd_downVelocity = 0.0f;
-uint16_t osd_throttle = 0;               // throtle
-float osd_alt = 0.0f;                    // altitude
-float osd_rel_alt = 0.0f;                                // relative altitude	//  jmmods
-float osd_climb = 0.0f;
-float osd_climb_ma[10];
-int osd_climb_ma_index = 0;
-float osd_total_trip_dist = 0;
+// This mutex controls access to the ad-hoc OSD State
+xSemaphoreHandle osd_state_adhoc_mutex;
 
-float nav_roll = 0.0f; // Current desired roll in degrees
-float nav_pitch = 0.0f; // Current desired pitch in degrees
-int16_t nav_bearing = 0; // Current desired heading in degrees
-int16_t wp_target_bearing = 0; // Bearing to current MISSION/target in degrees
-int8_t wp_target_bearing_rotate_int = 0;
-uint16_t wp_dist = 0; // Distance to active MISSION in meters
-uint8_t wp_number = 0; // Current waypoint number
-float alt_error = 0.0f; // Current altitude error in meters
-float aspd_error = 0.0f; // Current airspeed error in meters/second
-float xtrack_error = 0.0f; // Current crosstrack error on x-y plane in meters
-float eff = 0.0f; //Efficiency
-uint8_t osd_linkquality = 0;
+// Clear certain global mutex'd structs to zeros
+// For use during startup, but not after. (The airlock
+// values persist between copy operations, and there
+// some values that begin their lives in the airlock.)
+void clear_certain_global_mutexed_structs() {
+    // The airlock has no specific owner, so we get this cleared here,
+    // rather than in a specific thread like osdproc or osdmavlink.
+    clear_osd_state_struct(&airlock_osd_state);
+    // The ad-hoc state has a global lifetime like the airlock, so again
+    // we clear it only here, once, at startup.
+    clear_other_ost_state_struct(&adhoc_osd_state);
+}
 
-bool motor_armed = false;
-bool last_motor_armed = false;
-uint8_t autopilot = 0;
-uint8_t base_mode = 0;
-uint32_t custom_mode = 0;
+// Initialize the various mutexes designed to protect variables shared between tasks.
+void variable_mutexes_init() {
 
-bool osd_chan_cnt_above_eight = false;
-uint16_t osd_chan1_raw = 0;
-uint16_t osd_chan2_raw = 0;
-uint16_t osd_chan3_raw = 0;
-uint16_t osd_chan4_raw = 0;
-uint16_t osd_chan5_raw = 0;
-uint16_t osd_chan6_raw = 0;
-uint16_t osd_chan7_raw = 0;
-uint16_t osd_chan8_raw = 0;
-uint16_t osd_chan9_raw = 0;
-uint16_t osd_chan10_raw = 0;
-uint16_t osd_chan11_raw = 0;
-uint16_t osd_chan12_raw = 0;
-uint16_t osd_chan13_raw = 0;
-uint16_t osd_chan14_raw = 0;
-uint16_t osd_chan15_raw = 0;
-uint16_t osd_chan16_raw = 0;
-uint8_t osd_rssi = 0; //raw value from mavlink
+    osd_state_mavlink_mutex = xSemaphoreCreateMutex();
+    xSemaphoreGive(osd_state_mavlink_mutex);
 
-uint8_t osd_got_home = 0;               // tels if got home position or not
-float osd_home_lat = 0.0f;               // home latidude
-float osd_home_lon = 0.0f;               // home longitude
-float osd_home_alt = 0.0f;
-long osd_home_distance = 0;          // distance from home
-uint32_t osd_home_bearing = 0;
-uint8_t osd_alt_cnt = 0;              // counter for stable osd_alt
-float osd_alt_prev = 0.0f;             // previous altitude
+    osd_state_airlock_mutex = xSemaphoreCreateMutex();
+    xSemaphoreGive(osd_state_airlock_mutex);
+    
+    osd_state_adhoc_mutex = xSemaphoreCreateMutex();
+    xSemaphoreGive(osd_state_adhoc_mutex);
 
-float osd_windSpeed = 0.0f;
-float osd_windDir = 0.0f;
+    osd_state_osdproc_mutex = xSemaphoreCreateMutex();
+    xSemaphoreGive(osd_state_osdproc_mutex);
+}
 
-volatile uint8_t current_panel = 1;
+// Copy an osd_state object in a thread-safe manner
+// May not succeed if the lock is not gained in tick_delay ticks
+void copy_osd_state_thread_safe(osd_state * p_osd_state_source, 
+                                osd_state * p_osd_state_target,
+                                TickType_t tick_delay) {    
+    if (xSemaphoreTake(osd_state_airlock_mutex, tick_delay) == pdTRUE ) {
+        // Note that we deliberately DO NOT call clear_osd_state_struct() on the target -
+        // this function can be used to copy TO the airlock, and there are values that
+        // start their lifetime IN the airlock, and doing so would erase them.
+        
+        // Copy current values
+        *p_osd_state_target = *p_osd_state_source;
+        // Release the airlock mutex
+        xSemaphoreGive(osd_state_airlock_mutex);
+    }    
+    else
+    {
+        // Did not succeed; values won't be copied.
+    }
+}
 
-float atti_mp_scale = 0.0;
-float atti_3d_scale = 0.0;
-uint32_t atti_3d_min_clipX = 0;
-uint32_t atti_3d_max_clipX = 0;
-uint32_t atti_3d_min_clipY = 0;
-uint32_t atti_3d_max_clipY = 0;
+/////////////////////////////////////////////////////////////
+/// Convenience accessors
+/////////////////////////////////////////////////////////////
+
+float get_atti_3d_scale() {
+  float atti_3d_scale = 0.0f;
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      atti_3d_scale = adhoc_osd_state.atti_3d_scale;
+      // Release the ad-hoc mutex
+      xSemaphoreGive(osd_state_adhoc_mutex);
+   }
+   return atti_3d_scale;
+}
+
+float get_atti_mp_scale() {
+  float atti_mp_scale = 0.0f;
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      atti_mp_scale = adhoc_osd_state.atti_mp_scale;
+      // Release the ad-hoc mutex
+      xSemaphoreGive(osd_state_adhoc_mutex);
+   }
+   return atti_mp_scale;
+}
+
+float get_current_consumed_mah() {
+  float current_consumed_mah = 0.0f;  
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      current_consumed_mah = adhoc_osd_state.osd_curr_consumed_mah;
+      // Release the ad-hoc mutex
+      xSemaphoreGive(osd_state_adhoc_mutex);
+   }
+   return current_consumed_mah;
+}
+
+uint32_t get_osd_home_bearing() {
+  uint32_t TEMP_osd_home_bearing = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_osd_home_bearing =  adhoc_osd_state.osd_home_bearing;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_osd_home_bearing;
+}
+
+void set_osd_home_bearing(uint32_t new_osd_home_bearing) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.osd_home_bearing = new_osd_home_bearing;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+float get_osd_home_lat() {
+  float TEMP_osd_home_lat = 0.0f;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_osd_home_lat =  adhoc_osd_state.osd_home_lat;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_osd_home_lat;
+}
+
+void set_osd_home_lat(long new_osd_home_lat) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.osd_home_lat = new_osd_home_lat;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+float get_osd_home_lon() {
+  float TEMP_osd_home_lon = 0.0f;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_osd_home_lon = adhoc_osd_state.osd_home_lon;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_osd_home_lon;
+}
+
+void set_osd_home_lon(long new_osd_home_lon) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.osd_home_lon = new_osd_home_lon;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+long get_osd_home_distance() {
+  long TEMP_osd_home_distance = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_osd_home_distance = adhoc_osd_state.osd_home_distance;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_osd_home_distance;
+}
+
+void set_osd_home_distance(long new_osd_home_distance) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.osd_home_distance = new_osd_home_distance;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_osd_got_home() {
+  uint8_t TEMP_osd_got_home = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_osd_got_home = adhoc_osd_state.osd_got_home;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_osd_got_home;
+}
+
+void set_osd_got_home(uint8_t new_osd_got_home) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.osd_got_home = new_osd_got_home;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_osd_alt_cnt() {
+  uint8_t TEMP_osd_alt_cnt = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_osd_alt_cnt = adhoc_osd_state.osd_alt_cnt;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_osd_alt_cnt;
+}
+
+void set_osd_alt_cnt(uint8_t new_osd_alt_cnt) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.osd_alt_cnt = new_osd_alt_cnt;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_osd_alt_prev() {
+  uint8_t TEMP_osd_alt_prev = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_osd_alt_prev = adhoc_osd_state.osd_alt_prev;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_osd_alt_prev;
+}
+
+void set_osd_alt_prev(uint8_t new_osd_alt_prev) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.osd_alt_prev = new_osd_alt_prev;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_osd_home_alt() {
+  uint8_t TEMP_osd_home_alt = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_osd_home_alt = adhoc_osd_state.osd_home_alt;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_osd_home_alt;
+}
+
+void set_osd_home_alt(uint8_t new_osd_home_alt) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.osd_home_alt = new_osd_home_alt;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_current_panel() {
+  uint8_t TEMP_current_panel = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_current_panel = adhoc_osd_state.current_panel;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_current_panel;
+}
+
+void set_current_panel(uint8_t new_current_panel) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.current_panel = new_current_panel;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_mavbeat() {
+  uint8_t TEMP_mavbeat = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_mavbeat = adhoc_osd_state.mavbeat;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_mavbeat;
+}
+
+void set_mavbeat(uint8_t new_mavbeat) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.mavbeat = new_mavbeat;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint32_t get_lastMAVBeat() {
+  uint32_t TEMP_lastMAVBeat = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_lastMAVBeat = adhoc_osd_state.lastMAVBeat;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_lastMAVBeat;
+}
+
+void set_lastMAVBeat(uint32_t new_lastMAVBeat) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.lastMAVBeat = new_lastMAVBeat;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint32_t get_lastWritePanel() {
+  uint32_t TEMP_lastWritePanel = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_lastWritePanel = adhoc_osd_state.lastWritePanel;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_lastWritePanel;
+}
+
+void set_lastWritePanel(uint32_t new_lastWritePanel) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.lastWritePanel = new_lastWritePanel;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_waitingMAVBeats() {
+  uint8_t TEMP_waitingMAVBeats = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_waitingMAVBeats = adhoc_osd_state.waitingMAVBeats;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_waitingMAVBeats;
+}
+
+void set_waitingMAVBeats(uint8_t new_waitingMAVBeats) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.waitingMAVBeats = new_waitingMAVBeats;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_mav_type() {
+  uint8_t TEMP_mav_type = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_mav_type = adhoc_osd_state.mav_type;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_mav_type;
+}
+
+void set_mav_type(uint8_t new_mav_type) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.mav_type = new_mav_type;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_mav_system() {
+  uint8_t TEMP_mav_system = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_mav_system = adhoc_osd_state.mav_system;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_mav_system;
+}
+
+void set_mav_system(uint8_t new_mav_system) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.mav_system = new_mav_system;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_mav_component() {
+  uint8_t TEMP_mav_component = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_mav_component = adhoc_osd_state.mav_component;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_mav_component;
+}
+
+void set_mav_component(uint8_t new_mav_component) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.mav_component = new_mav_component;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint8_t get_enable_mav_request() {
+  uint8_t TEMP_enable_mav_request = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_enable_mav_request = adhoc_osd_state.enable_mav_request;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_enable_mav_request;
+}
+
+void set_enable_mav_request(uint8_t new_enable_mav_request) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.enable_mav_request = new_enable_mav_request;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint32_t get_sys_start_time() {
+  uint32_t TEMP_sys_start_time = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_sys_start_time = adhoc_osd_state.sys_start_time;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_sys_start_time;
+}
+
+void set_sys_start_time(uint32_t new_sys_start_time) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.sys_start_time = new_sys_start_time;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint32_t get_heartbeat_start_time() {
+  uint32_t TEMP_heartbeat_start_time = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_heartbeat_start_time = adhoc_osd_state.heartbeat_start_time;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_heartbeat_start_time;
+}
+
+void set_heartbeat_start_time(uint32_t new_heartbeat_start_time) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.heartbeat_start_time = new_heartbeat_start_time;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint32_t get_armed_start_time() {
+  uint32_t TEMP_armed_start_time = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_armed_start_time = adhoc_osd_state.armed_start_time;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_armed_start_time;
+}
+
+void set_armed_start_time(uint32_t new_armed_start_time) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.armed_start_time = new_armed_start_time;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
+
+uint32_t get_total_armed_time() {
+  uint32_t TEMP_total_armed_time = 0;
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      TEMP_total_armed_time = adhoc_osd_state.total_armed_time;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+  return TEMP_total_armed_time;
+}
+
+void set_total_armed_time(uint32_t new_total_armed_time) {
+  // Get ad-hoc mutex
+  if (xSemaphoreTake(osd_state_adhoc_mutex, portMAX_DELAY) == pdTRUE ) {
+      adhoc_osd_state.total_armed_time = new_total_armed_time;
+      // Release the ad-hoc mutex      
+      xSemaphoreGive(osd_state_adhoc_mutex);
+  }  
+}
 
 
-uint8_t got_mission_counts = 0;
-uint8_t enable_mission_count_request = 0;
-uint16_t mission_counts = 0;
-uint8_t enable_mission_item_request = 0;
-uint16_t current_mission_item_req_index = 0;
-
-uint16_t wp_counts = 0;
-uint8_t got_all_wps = 0;
-WAYPOINT wp_list[MAX_WAYPOINTS];
-
-int8_t osd_offset_Y = 0;
-int8_t osd_offset_X = 0;

--- a/src/uavtalk.c
+++ b/src/uavtalk.c
@@ -24,6 +24,9 @@
 extern xSemaphoreHandle onUAVTalkSemaphore;
 extern uint8_t *mavlink_buffer_proc;
 
+// This is the OSD state that the UAVTalk thread owns
+osd_state uavtalk_osd_state;
+
 static unsigned long last_gcstelemetrystats_send = 0;
 static unsigned long last_flighttelemetry_connect = 0;
 static uint8_t gcstelemetrystatus = TELEMETRYSTATS_STATE_DISCONNECTED;
@@ -292,7 +295,9 @@ void parseUAVTalk(void) {
 //	uint8_t show_prio_info = 0;
   uint8_t c;
   uint32_t index = 0;
-
+  float osd_lat_current;
+  float osd_lon_current;
+  
 #ifdef FLIGHT_BATT_ON_REVO
   if (gcstelemetrystatus == TELEMETRYSTATS_STATE_CONNECTED && !inited) {
     /* Request flight battery settings */
@@ -300,6 +305,7 @@ void parseUAVTalk(void) {
     inited = 1;
   }
 #endif
+
 
 
   while (index < MAVLINK_BUFFER_SIZE)
@@ -330,13 +336,14 @@ void parseUAVTalk(void) {
       case ATTITUDESTATE_OBJID:
         last_flighttelemetry_connect = GetSystimeMS();
 //					show_prio_info = 1;
-        osd_roll                = (int16_t) uavtalk_get_float(&msg, ATTITUDEACTUAL_OBJ_ROLL);
-        osd_pitch               = (int16_t) uavtalk_get_float(&msg, ATTITUDEACTUAL_OBJ_PITCH);
-        osd_yaw                 = (int16_t) uavtalk_get_float(&msg, ATTITUDEACTUAL_OBJ_YAW);
-        // if we don't have a GPS, use Yaw for heading
-        if (osd_lat == 0) {
-          osd_heading = osd_yaw;
-        }
+        uavtalk_osd_state.osd_roll                = (int16_t) uavtalk_get_float(&msg, ATTITUDEACTUAL_OBJ_ROLL);
+        uavtalk_osd_state.osd_pitch               = (int16_t) uavtalk_get_float(&msg, ATTITUDEACTUAL_OBJ_PITCH);
+        uavtalk_osd_state.osd_yaw                 = (int16_t) uavtalk_get_float(&msg, ATTITUDEACTUAL_OBJ_YAW);
+        
+        // if we don't have a GPS, use Yaw for heading        
+         if (osd_lat_current == 0) {
+           uavtalk_osd_state.osd_heading = uavtalk_osd_state.osd_yaw;
+         }
         break;
       case FLIGHTSTATUS_OBJID:
       case FLIGHTSTATUS_OBJID_001:
@@ -345,13 +352,15 @@ void parseUAVTalk(void) {
       case FLIGHTSTATUS_OBJID_004:
       case FLIGHTSTATUS_OBJID_005:
         //osd_armed		= uavtalk_get_int8(&msg, FLIGHTSTATUS_OBJ_ARMED);
-        custom_mode                = uavtalk_get_int8(&msg, FLIGHTSTATUS_OBJ_FLIGHTMODE);
+        uavtalk_osd_state.custom_mode                = uavtalk_get_int8(&msg, FLIGHTSTATUS_OBJ_FLIGHTMODE);
         break;
       case MANUALCONTROLCOMMAND_OBJID:
       case MANUALCONTROLCOMMAND_OBJID_001:
       case MANUALCONTROLCOMMAND_OBJID_002:
-        osd_throttle            = (int16_t) (100.0 * uavtalk_get_float(&msg, MANUALCONTROLCOMMAND_OBJ_THROTTLE));
-        if (osd_throttle < 0 || osd_throttle > 200) osd_throttle = 0;
+        uavtalk_osd_state.osd_throttle            = (int16_t) (100.0 * uavtalk_get_float(&msg, MANUALCONTROLCOMMAND_OBJ_THROTTLE));
+        if (uavtalk_osd_state.osd_throttle < 0 || uavtalk_osd_state.osd_throttle > 200) {
+            uavtalk_osd_state.osd_throttle = 0;
+        }
         // Channel mapping:
         // 0   is Throttle
         // 1-2 are Roll / Pitch
@@ -362,32 +371,37 @@ void parseUAVTalk(void) {
         // In OPOSD:
         // chanx_raw     used for menu navigation (Roll/pitch)
         // osd_chanx_raw used for panel navigation (Accessory)
-        osd_chan1_raw       = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_1);
-        osd_chan2_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_2);
-        osd_chan5_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_4);
-        osd_chan6_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_6);
-        osd_chan7_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_7);
-        osd_chan8_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_8);
+        uavtalk_osd_state.osd_chan1_raw       = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_1);
+        uavtalk_osd_state.osd_chan2_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_2);
+        uavtalk_osd_state.osd_chan5_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_4);
+        uavtalk_osd_state.osd_chan6_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_6);
+        uavtalk_osd_state.osd_chan7_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_7);
+        uavtalk_osd_state.osd_chan8_raw   = uavtalk_get_int16(&msg, MANUALCONTROLCOMMAND_OBJ_CHANNEL_8);
         break;
       case GPSPOSITION_OBJID:
       case GPSPOSITIONSENSOR_OBJID:
       case GPSPOSITIONSENSOR_OBJID_001:
-        osd_lat                 = uavtalk_get_int32(&msg, GPSPOSITION_OBJ_LAT);
-        osd_lon                 = uavtalk_get_int32(&msg, GPSPOSITION_OBJ_LON);
-        osd_satellites_visible  = uavtalk_get_int8(&msg, GPSPOSITION_OBJ_SATELLITES);
-        osd_fix_type            = uavtalk_get_int8(&msg, GPSPOSITION_OBJ_STATUS);
-        osd_heading             = uavtalk_get_float(&msg, GPSPOSITION_OBJ_HEADING);
-        osd_alt                 = uavtalk_get_float(&msg, GPSPOSITION_OBJ_ALTITUDE);
-        osd_groundspeed         = uavtalk_get_float(&msg, GPSPOSITION_OBJ_GROUNDSPEED);
+        osd_lat_current = uavtalk_get_int32(&msg, GPSPOSITION_OBJ_LAT);
+        osd_lon_current = uavtalk_get_int32(&msg, GPSPOSITION_OBJ_LON);
+
+        uavtalk_osd_state.osd_lat = osd_lat_current;
+        uavtalk_osd_state.osd_lon = osd_lon_current;
+                
+        uavtalk_osd_state.osd_satellites_visible  = uavtalk_get_int8(&msg, GPSPOSITION_OBJ_SATELLITES);
+        uavtalk_osd_state.osd_fix_type            = uavtalk_get_int8(&msg, GPSPOSITION_OBJ_STATUS);
+        uavtalk_osd_state.osd_heading             = uavtalk_get_float(&msg, GPSPOSITION_OBJ_HEADING);        
+        uavtalk_osd_state.osd_alt = uavtalk_get_float(&msg, GPSPOSITION_OBJ_ALTITUDE);
+        
+        uavtalk_osd_state.osd_groundspeed         = uavtalk_get_float(&msg, GPSPOSITION_OBJ_GROUNDSPEED);
         break;
       case GPSVELOCITY_OBJID:
       case GPSVELOCITYSENSOR_OBJID:
-        osd_climb               = -1.0 * uavtalk_get_float(&msg, GPSVELOCITY_OBJ_DOWN);
+        uavtalk_osd_state.osd_climb               = -1.0 * uavtalk_get_float(&msg, GPSVELOCITY_OBJ_DOWN);
         break;
       case FLIGHTBATTERYSTATE_OBJID:
       case FLIGHTBATTERYSTATE_OBJID_001:
-        osd_vbat_A              = uavtalk_get_float(&msg, FLIGHTBATTERYSTATE_OBJ_VOLTAGE);
-        osd_curr_A              = (int16_t) (100.0 * uavtalk_get_float(&msg, FLIGHTBATTERYSTATE_OBJ_CURRENT));
+        uavtalk_osd_state.osd_vbat_A              = uavtalk_get_float(&msg, FLIGHTBATTERYSTATE_OBJ_VOLTAGE);
+        uavtalk_osd_state.osd_curr_A              = (int16_t) (100.0 * uavtalk_get_float(&msg, FLIGHTBATTERYSTATE_OBJ_CURRENT));
         //osd_total_A		= (int16_t) uavtalk_get_float(&msg, FLIGHTBATTERYSTATE_OBJ_CONSUMED_ENERGY);
         //osd_est_flight_time	= (int16_t) uavtalk_get_float(&msg, FLIGHTBATTERYSTATE_OBJ_ESTIMATED_FLIGHT_TIME);
         break;
@@ -425,13 +439,20 @@ void parseUAVTalk(void) {
 
 }
 
+void copyNewUavtalkValuesToAirlock() {
+    // Uavtalk is presumed to be the slower thread, and more tolerant of delays. Therefore
+    // we use a large timeout for the Mutex.
+    copy_osd_state_thread_safe(&uavtalk_osd_state, &airlock_osd_state, portMAX_DELAY);
+}
+
 void UAVTalkTask(void *pvParameters) {
   mavlink_usart_init(get_map_bandrate(eeprom_buffer.params.uart_bandrate));
-  sys_start_time = GetSystimeMS();
+  set_sys_start_time(GetSystimeMS());
 
   while (1)
   {
     xSemaphoreTake(onUAVTalkSemaphore, portMAX_DELAY);
     parseUAVTalk();
+    copyNewUavtalkValuesToAirlock();    
   }
 }

--- a/src/uavtalk.c
+++ b/src/uavtalk.c
@@ -442,7 +442,7 @@ void parseUAVTalk(void) {
 void copyNewUavtalkValuesToAirlock() {
     // Uavtalk is presumed to be the slower thread, and more tolerant of delays. Therefore
     // we use a large timeout for the Mutex.
-    copy_osd_state_thread_safe(&uavtalk_osd_state, &airlock_osd_state, portMAX_DELAY);
+    copy_osd_state(&uavtalk_osd_state, &airlock_osd_state, portMAX_DELAY);
 }
 
 void UAVTalkTask(void *pvParameters) {


### PR DESCRIPTION
This attempts to add concurrency protection by using FreeRTOS Mutexes to protect access to global variables, under the assumption that unprotected access may be causing difficult to reproduce, erratic errors.

I am not completely confident that these fixes repair problems we've had with PlayUAV (like bad home direction or erratic altitude), but it seems worth trying. Even if it does not solve our issues, we can proceed knowing the source of the problem(s) is unlikely to be improper access to global variables across tasks/threads.

This is a large change, but mostly mechanical in nature. I have compartmentalized more functions as part of the process though.

See also https://github.com/TobiasBales/PlayuavOSDConfigurator/pull/84