### PR TITLE
Adding dedicated control for home arrow debugging

### DIFF
--- a/inc/osdconfig.h
+++ b/inc/osdconfig.h
@@ -7,10 +7,10 @@
 #define EERROM_SIZE                             1024
 
 // Version number: major.minor.revision (1.2.6 for example)
-#define PLAYUAV_VERSION_NUMBER          "1.2.0"
+#define PLAYUAV_VERSION_NUMBER          "1.3.0"
 // Change this to distinguish the release in some fashion that
 // version number doesn't cover
-#define PLAYUAV_VERSION_DESCRIPTION     "RC CHANNELS - 11/07/2016"
+#define PLAYUAV_VERSION_DESCRIPTION     "HOME DIR DEBUG - 11/09/2016"
 
 void vTaskVCP(void *pvParameters);
 
@@ -359,7 +359,7 @@ typedef union {
     uint16_t Watts_posY;
     uint16_t Watts_fontsize;
     uint16_t Watts_align;
-    
+
     // From firmware_ver 11, PLAYUAV_VERSION 1.1.1, "SLG BETA 1"
     
     // Number of milliseconds to show the version splash panel
@@ -373,6 +373,13 @@ typedef union {
     uint16_t RC_Channels_panel;
     uint16_t RC_Channels_posx;
     uint16_t RC_Channels_posy;
+    
+    // From firmware_ver 14
+    uint16_t HomeDirectionDebugInfo_enabled;
+    uint16_t HomeDirectionDebugInfo_panel;
+    uint16_t HomeDirectionDebugInfo_posX;
+    uint16_t HomeDirectionDebugInfo_posY;    
+    
     
 //		//below is unused. if add a param, reduce one item here
 //		uint16_t unused[EERROM_SIZE/2 - 104];

--- a/inc/osdproc.h
+++ b/inc/osdproc.h
@@ -31,7 +31,7 @@ void draw_uav2d(void);
 void draw_throttle(void);
 void draw_simple_attitude(void);
 void draw_home_direction(void);
-void draw_home_direction_debug_info(int x, int y, float absolute_home_bearing, float uav_compass_bearing, float relative_home_bearing);
+void draw_home_direction_debug_info(float absolute_home_bearing, float uav_compass_bearing, float relative_home_bearing);
 void draw_radar(void);
 void draw_flight_mode(void);
 void draw_arm_state(void);

--- a/src/board.c
+++ b/src/board.c
@@ -597,6 +597,15 @@ void checkDefaultParam() {
     bNeedUpdateFlash = true;
   }
   
+  if (eeprom_buffer.params.firmware_ver < 14) {
+    eeprom_buffer.params.firmware_ver = 14;
+    eeprom_buffer.params.HomeDirectionDebugInfo_enabled = 0;
+    eeprom_buffer.params.HomeDirectionDebugInfo_panel = 2;
+    eeprom_buffer.params.HomeDirectionDebugInfo_posX = 65;
+    eeprom_buffer.params.HomeDirectionDebugInfo_posY = 70;
+    bNeedUpdateFlash = true;
+  }  
+  
   bool ret = false;
   if (bNeedUpdateFlash)
   {

--- a/src/osdproc.c
+++ b/src/osdproc.c
@@ -531,24 +531,32 @@ void draw_home_direction() {
   }
 
   // For debugging the infamous bad home direction bug
-  draw_home_direction_debug_info(x, y, absolute_home_bearing, uav_compass_bearing, relative_home_bearing);
+  draw_home_direction_debug_info(absolute_home_bearing, uav_compass_bearing, relative_home_bearing);
 }
 
 // Debug output for direction to home calculation
-void draw_home_direction_debug_info(int x, int y, float absolute_home_bearing, float uav_compass_bearing, float relative_home_bearing)
+void draw_home_direction_debug_info(float absolute_home_bearing, float uav_compass_bearing, float relative_home_bearing)
 {
+  if (!enabledAndShownOnPanel(eeprom_buffer.params.HomeDirectionDebugInfo_enabled,
+                              eeprom_buffer.params.HomeDirectionDebugInfo_panel)) {
+    return;
+  }    
+       
+  int xPos = eeprom_buffer.params.HomeDirectionDebugInfo_posX;
+  int yPos = eeprom_buffer.params.HomeDirectionDebugInfo_posY;    
+    
   char tmp_str[15] = { 0 };
   // font_index: 0 = small, 1 = medium, 2 = large
   int font_index = 0;
   
   sprintf(tmp_str, "abs h.b. %d", (int32_t)absolute_home_bearing);
-  write_string(tmp_str, x, y + 15, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[font_index]);
+  write_string(tmp_str, xPos, yPos + 15, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[font_index]);
   
   sprintf(tmp_str, "rel h.b. %d", (int32_t)relative_home_bearing);
-  write_string(tmp_str, x, y + 30, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[font_index]);
+  write_string(tmp_str, xPos, yPos + 30, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[font_index]);
   
   sprintf(tmp_str, "comp. b %d", (int32_t)uav_compass_bearing);
-  write_string(tmp_str, x, y + 45, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[font_index]);  
+  write_string(tmp_str, xPos, yPos + 45, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, SIZE_TO_FONT[font_index]);  
 }
 
 void draw_uav2d() {


### PR DESCRIPTION
This allows user to turn the home arrow debug text on or off, and to position it independently of the home arrow itself.
![homedirectiondebuginfo](https://cloud.githubusercontent.com/assets/7128339/20180620/0fa3c6dc-a710-11e6-9a99-7aca6a086df6.jpg)

See also https://github.com/TobiasBales/PlayuavOSDConfigurator/pull/87