### PR TITLE
Removing auto refresh of waypoints on panel switch

### DIFF
--- a/inc/osdconfig.h
+++ b/inc/osdconfig.h
@@ -7,10 +7,10 @@
 #define EERROM_SIZE                             1024
 
 // Version number: major.minor.revision (1.2.6 for example)
-#define PLAYUAV_VERSION_NUMBER          "1.3.0"
+#define PLAYUAV_VERSION_NUMBER          "1.3.1"
 // Change this to distinguish the release in some fashion that
 // version number doesn't cover
-#define PLAYUAV_VERSION_DESCRIPTION     "HOME DIR DEBUG - 11/09/2016"
+#define PLAYUAV_VERSION_DESCRIPTION     "WAYPOINT SINGLE LOAD - 11/16/2016"
 
 void vTaskVCP(void *pvParameters);
 

--- a/src/board.c
+++ b/src/board.c
@@ -443,12 +443,6 @@ void triggerPanel(void) {
       // Release the ad-hoc mutex
       xSemaphoreGive(osd_state_adhoc_mutex);
     }
-    
-    // If we changed panels, reload the waypoints 
-    // TODO: Make conditional on EEPROM value to allow configuration
-    if (panel_value_changed) {
-        request_reload_of_waypoints_outside_mavlink_thread();
-    }
 }
 
 uint32_t GetSystimeMS(void) {


### PR DESCRIPTION
The code being removed worked, and was a reasonable idea to test, but in my experience it is too slow to tolerate. Reloading 8 waypoints took 5-10 seconds, which is an eternity in fast-paced FPV. If it was just a momentary blink I think it would have been tolerable as an interim hack, but no.

Really Mavlink needs a way to tell OSDs about the changes to waypoints/home location, and that's what needs to be changed first -- the Mavlink protocol. Mavlink 2.0 may allow us to do this, but I haven't looked into it in detail yet. That's what the original code was addressing -- trying to make the OSD keep up with changes to the home location/waypoints.