### PR TITLE
Fixing __packed compiler warning on newer ARM toolchain distributions

### DIFF
--- a/inc/usb_conf.h
+++ b/inc/usb_conf.h
@@ -104,16 +104,17 @@
 #endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
 
 /* __packed keyword used to decrease the data type alignment to 1-byte */
-#if defined (__CC_ARM)         /* ARM Compiler */
-  #define __packed    __packed
-#elif defined (__ICCARM__)     /* IAR Compiler */
-  #define __packed    __packed
-#elif defined   (__GNUC__)     /* GNU Compiler */
-  #define __packed    __attribute__ ((__packed__))
-#elif defined   (__TASKING__)  /* TASKING Compiler */
-  #define __packed    __unaligned
-#endif /* __CC_ARM */
-
+#ifndef __packed
+  #if defined (__CC_ARM)         /* ARM Compiler */
+    #define __packed    __packed
+  #elif defined (__ICCARM__)     /* IAR Compiler */
+    #define __packed    __packed
+  #elif defined   (__GNUC__)     /* GNU Compiler */
+    #define __packed    __attribute__ ((__packed__))
+  #elif defined   (__TASKING__)  /* TASKING Compiler */
+    #define __packed    __unaligned
+  #endif /* __CC_ARM */
+#endif /* __packed */
 
 #endif //__USB_CONF__H__
 


### PR DESCRIPTION
Fixes annoying compiler warning:

```
In file included from ./inc/usbd_conf.h:31:0,
                 from ./lib/STM32F4-Discovery_FW_V1.1.0/Libraries/STM32_USB_Device_Library/Core/inc/usbd_def.h:34,
                 from ./lib/STM32F4-Discovery_FW_V1.1.0/Libraries/STM32_USB_Device_Library/Core/inc/usbd_ioreq.h:34,
                 from ./lib/STM32F4-Discovery_FW_V1.1.0/Libraries/STM32_USB_Device_Library/Class/cdc/inc/usbd_cdc_core.h
:33,
                 from src/osdconfig.c:19:
./inc/usb_conf.h:112:0: warning: "__packed" redefined
   #define __packed    __attribute__ ((__packed__))
 ^
In file included from c:\pixhawk_toolchain\toolchain\arm-none-eabi\include\stdlib.h:19:0,
                 from ./inc/board.h:7,
                 from ./inc/osdconfig.h:4,
                 from src/osdconfig.c:17:
c:\pixhawk_toolchain\toolchain\arm-none-eabi\include\sys\cdefs.h:250:0: note: this is the location of the previous defin
ition
 #define __packed __attribute__((__packed__))
 ^
arm-none-eabi-objcopy -O binary -S PlayuavOSD.elf PlayuavOSD.bin

```

**The definition of __packed from the latest toolchains is identical, so if available we defer to it.**