### PR TITLE
Fixing an annoying spelling error in a define. 

### DIFF
--- a/inc/max7456.h
+++ b/inc/max7456.h
@@ -10,7 +10,7 @@
 #define MAX7456_MODE_MASK_PAL 0x40 //PAL mask 01000000
 #define MAX7456_CENTER_PAL 0x8
 
-#define MAX7456_MODE_MASK_NTCS 0x00 //NTSC mask 00000000 ("|" will do nothing)
+#define MAX7456_MODE_MASK_NTSC 0x00 //NTSC mask 00000000 ("|" will do nothing)
 #define MAX7456_CENTER_NTSC 0x6
 
 //MAX7456 reg read addresses

--- a/src/max7456.c
+++ b/src/max7456.c
@@ -106,7 +106,7 @@ void SPI_MAX7456_setMode(int mode) {
   switch (mode)
   {
   case 0:
-    max7456_videoMode = MAX7456_MODE_MASK_NTCS;
+    max7456_videoMode = MAX7456_MODE_MASK_NTSC;
     break;
   case 1:
     max7456_videoMode = MAX7456_MODE_MASK_PAL;


### PR DESCRIPTION
MAX7456_MODE_MASK_NTCS => MAX7456_MODE_MASK_NTSC

This should have zero impact to compiled code, so not bumping version number.